### PR TITLE
Update updating.md

### DIFF
--- a/static/updating.md
+++ b/static/updating.md
@@ -58,7 +58,8 @@ After clicking the "Connect" button, if you do not see a "USB Serial" port liste
 
 With the Lite fully updated and connected to WiFi, the final step is to connect it to Home Assistant.
 
-[Connecting to Home Assistant](./Home Assistant/connecting-home-assistant.html){: .btn .btn-blue }
+[Connecting to Home Assistant](./Home%20Assistant/connecting-home-assistant.html){: .btn .btn-blue } 
+
 
 <script
   type="module"


### PR DESCRIPTION
Trying to fix "Connecting to Home Assistant" link

This URL https://everythingsmarthome.github.io/everything-presence-lite/updating.html has a broken link at the bottom of the page. This patch tries to fix the markdown to fix it.

![image](https://github.com/EverythingSmartHome/everything-presence-lite/assets/578882/1c0ba1a9-67da-407e-9c75-30699e3e8760)
