### PR TITLE
Fix device class for angle

### DIFF
--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -405,21 +405,18 @@ sensor:
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
-    device_class: distance
   - platform: template
     name: "Target 2 Angle"
     id: target2_angle
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
-    device_class: distance
   - platform: template
     name: "Target 3 Angle"
     id: target3_angle
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
-    device_class: distance
   - platform: template
     name: "Target 1 Distance"
     id: target1_distance


### PR DESCRIPTION
Fixes an issue that would generate logs in Home Assistant because of an incorrect device class:

```
Entity sensor.everything_presence_lite_24e5fc_target_1_angle (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement '°' which is not a valid unit for the device class ('distance') it is using; expected one of ['yd', 'mi', 'mm', 'm', 'cm', 'ft', 'km', 'in']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+esphome%22
Entity sensor.everything_presence_lite_24e5fc_target_2_angle (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement '°' which is not a valid unit for the device class ('distance') it is using; expected one of ['yd', 'mi', 'mm', 'm', 'cm', 'ft', 'km', 'in']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+esphome%22
Entity sensor.everything_presence_lite_24e5fc_target_3_angle (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement '°' which is not a valid unit for the device class ('distance') it is using; expected one of ['yd', 'mi', 'mm', 'm', 'cm', 'ft', 'km', 'in']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+esphome%22
```