### PR TITLE
fix issue #37 (EPL occupancy going clear with target 1 inactive and target 2 active)

### DIFF
--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -67,13 +67,9 @@ binary_sensor:
     filters:
       - delayed_off: !lambda return (id(off_delay).state *1000);
     lambda: |-
-      if(id(target1_x).state != 0) {
-        return true;
-      } else if(id(target1_y).state != 0) {
-        return true;
-      } else {
-        return false;
-      }
+      return (id(target1_distance).state != 0
+        || id(target2_distance).state != 0
+        || id(target3_distance).state != 0);
   - platform: template
     name: "Zone 1 Occupancy"
     id: zone1_occupancy


### PR DESCRIPTION
global occupancy checks for all three targets instead of just target 1 (which rarely can be inactive while targets 2 and/or 3 are not)