### PR TITLE
Add firmware option without Bluetooth proxy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,22 @@ on:
       - '**.yaml'
 
 jobs:
-  publish-everything-presence-one:
+  publish-everything-presence-lite-ha:
     name: Publish Everything Presence Lite
     uses: esphome/workflows/.github/workflows/publish.yml@main
     with:
       files: everything-presence-lite-ha.yaml
       name: Everything Presence Lite HA
       manifest_filename: everything-presence-lite-ha-manifest.json
+      clean: false
+      esphome_version: latest
+  publish-everything-presence-lite-no-ble:
+    name: Publish Everything Presence Lite without BLE
+    uses: esphome/workflows/.github/workflows/publish.yml@main
+    with:
+      files: everything-presence-lite-ha-no-ble.yaml
+      name: Everything Presence Lite HA No BLE
+      manifest_filename: everything-presence-lite-ha-no-ble-manifest.json
       clean: false
       esphome_version: latest
 #  publish-everything-presence-one-smartthings:

--- a/everything-presence-lite-ha-no-ble.yaml
+++ b/everything-presence-lite-ha-no-ble.yaml
@@ -1,0 +1,779 @@
+substitutions:
+  name: "everything-presence-lite"
+  friendly_name: "Everything Presence Lite"
+  illuminance_update_interval: "2s"
+  hidden_ssid: "false"
+
+esphome:
+  name: ${name}
+  comment: Everything Presence Lite
+  friendly_name: ${friendly_name}
+  name_add_mac_suffix: True
+  project: 
+    name: EverythingSmartTechnology.Everything Presence Lite
+    version: "1.0.1"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+  level: ERROR
+
+# Enable Home Assistant API
+api:
+
+ota:
+
+wifi:
+  ap: {}
+
+dashboard_import:
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha.yaml@main
+  import_full_config: false # or true
+
+improv_serial:
+
+improv_esp32:
+  authorizer: NONE
+
+globals:
+  - id: mmwave_update_time
+    type: unsigned long
+    restore_value: no
+    initial_value: '0'
+
+i2c:
+ sda: 21
+ scl: 22
+ scan: true
+
+light:
+  - platform: status_led
+    name: ESP32 LED
+    pin: GPIO14
+    internal: False
+    restore_mode: ALWAYS_OFF
+
+binary_sensor:
+  - platform: template
+    name: "Occupancy"
+    device_class: occupancy
+    filters:
+      - delayed_off: !lambda return (id(off_delay).state *1000);
+    lambda: |-
+      if(id(target1_x).state != 0) {
+        return true;
+      } else if(id(target1_y).state != 0) {
+        return true;
+      } else {
+        return false;
+      }
+  - platform: template
+    name: "Zone 1 Occupancy"
+    id: zone1_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_1_off_delay).state *1000);
+  - platform: template
+    name: "Zone 2 Occupancy"
+    id: zone2_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_2_off_delay).state *1000);
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 Occupancy"
+    id: zone3_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_3_off_delay).state *1000);
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 Occupancy"
+    id: zone4_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_4_off_delay).state *1000);
+    disabled_by_default: true
+  - platform: template
+    name: "Target 1 Active"
+    id: target1_active
+    lambda: |-
+      return id(target1_distance).state != 0;
+  - platform: template
+    name: "Target 2 Active"
+    id: target2_active
+    lambda: |-
+      return id(target2_distance).state != 0;
+  - platform: template
+    name: "Target 3 Active"
+    id: target3_active
+    lambda: |-
+      return id(target3_distance).state != 0;
+
+number:
+  - platform: template
+    name: "Illuminance Offset"
+    id: illuminance_offset_ui
+    unit_of_measurement: "lx"
+    min_value: -100
+    max_value: 100
+    step: 5
+    mode: slider
+    update_interval: never
+    optimistic: true
+    restore_value: true
+    initial_value: 0
+    icon: "mdi:brightness-5"
+    entity_category: config
+    on_value:
+      - lambda: 'id(illuminance_sensor).update();'
+  - platform: template
+    name: "Occupancy Off Delay"
+    id: off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+  - platform: template
+    name: "Max Distance"
+    id: distance
+    max_value: 600
+    min_value: 0
+    unit_of_measurement: "cm"
+    step: 1
+    optimistic: True
+    restore_value: True
+    initial_value: 600
+
+  - platform: template
+    name: "Zone 1 Begin X"
+    id: zone1_begin_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    initial_value: -4000
+  - platform: template
+    name: "Zone 1 End X"
+    id: zone1_end_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    initial_value: 4000
+  - platform: template
+    name: "Zone 1 Begin Y"
+    id: zone1_begin_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    initial_value: 0
+  - platform: template
+    name: "Zone 1 End Y"
+    id: zone1_end_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    initial_value: 6000
+  - platform: template
+    name: "Zone 1 Occupancy Off Delay"
+    id: zone_1_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+
+  - platform: template
+    name: "Zone 2 Begin X"
+    id: zone2_begin_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 2 End X"
+    id: zone2_end_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 2 Begin Y"
+    id: zone2_begin_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 2 End Y"
+    id: zone2_end_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 2 Occupancy Off Delay"
+    id: zone_2_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+    disabled_by_default: true
+
+  - platform: template
+    name: "Zone 3 Begin X"
+    id: zone3_begin_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 End X"
+    id: zone3_end_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 Begin Y"
+    id: zone3_begin_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 End Y"
+    id: zone3_end_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 Occupancy Off Delay"
+    id: zone_3_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+    disabled_by_default: true
+
+  - platform: template
+    name: "Zone 4 Begin X"
+    id: zone4_begin_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 End X"
+    id: zone4_end_x
+    max_value: 4000
+    min_value: -4000
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 Begin Y"
+    id: zone4_begin_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 End Y"
+    id: zone4_end_y
+    max_value: 6000
+    min_value: 0
+    unit_of_measurement: "mm"
+    step: 10
+    optimistic: True
+    restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 Occupancy Off Delay"
+    id: zone_4_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+    disabled_by_default: true
+
+sensor:
+  - platform: bh1750
+    name: Illuminance
+    id: illuminance_sensor
+    address: 0x23
+    update_interval: ${illuminance_update_interval}
+    filters:
+      - lambda: "return x + id(illuminance_offset_ui).state;"
+  - platform: template
+    name: "Target 1 X"
+    id: target1_x
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 1 Y"
+    id: target1_y
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 1 Speed"
+    id: target1_speed
+    accuracy_decimals: 2
+    unit_of_measurement: 'm/s'
+    state_class: measurement
+    device_class: speed
+  - platform: template
+    name: "Target 1 Resolution"
+    id: target1_resolution
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 2 X"
+    id: target2_x
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 2 Y"
+    id: target2_y
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 2 Speed"
+    id: target2_speed
+    accuracy_decimals: 2
+    unit_of_measurement: 'm/s'
+    state_class: measurement
+    device_class: speed
+  - platform: template
+    name: "Target 2 Resolution"
+    id: target2_resolution
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 3 X"
+    id: target3_x
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 3 Y"
+    id: target3_y
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 3 Speed"
+    id: target3_speed
+    accuracy_decimals: 2
+    unit_of_measurement: 'm/s'
+    state_class: measurement
+    device_class: speed
+  - platform: template
+    name: "Target 3 Resolution"
+    id: target3_resolution
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 1 Angle"
+    id: target1_angle
+    accuracy_decimals: 0
+    unit_of_measurement: '°'
+    state_class: measurement
+  - platform: template
+    name: "Target 2 Angle"
+    id: target2_angle
+    accuracy_decimals: 0
+    unit_of_measurement: '°'
+    state_class: measurement
+  - platform: template
+    name: "Target 3 Angle"
+    id: target3_angle
+    accuracy_decimals: 0
+    unit_of_measurement: '°'
+    state_class: measurement
+  - platform: template
+    name: "Target 1 Distance"
+    id: target1_distance
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 2 Distance"
+    id: target2_distance
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Target 3 Distance"
+    id: target3_distance
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    state_class: measurement
+    device_class: distance
+  - platform: template
+    name: "Zone 1 Target Count"
+    id: zone1_target_count
+    accuracy_decimals: 0
+  - platform: template
+    name: "Zone 2 Target Count"
+    id: zone2_target_count
+    accuracy_decimals: 0
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 3 Target Count"
+    id: zone3_target_count
+    accuracy_decimals: 0
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 Target Count"
+    id: zone4_target_count
+    accuracy_decimals: 0
+    disabled_by_default: true
+
+uart:
+  id: uart_bus
+  tx_pin: 
+    number: GPIO17
+    mode:
+      input: true
+      pullup: true
+  rx_pin: 
+    number: GPIO16
+    mode:
+      input: true
+      pullup: true
+  baud_rate: 256000
+  parity: NONE
+  stop_bits: 1
+  data_bits: 8
+  debug:
+    direction: BOTH
+    dummy_receiver: True
+    after:
+     delimiter: [0X55, 0XCC]
+    sequence:
+      # - lambda: UARTDebug::log_hex(direction, bytes, ' ');
+      - lambda: |-
+          if ((millis() - id(mmwave_update_time)) <= 1000) { 
+            return;
+          };
+          id(mmwave_update_time) = millis();
+
+          int16_t p1_x = (uint16_t((bytes[5] << 8) | bytes[4] ));
+          if ((bytes[5] & 0x80) >> 7){
+            p1_x -= pow(2, 15); 
+          }else{
+            p1_x = 0 - p1_x; // was 0 - p1_x;
+          }
+          p1_x = -p1_x;
+
+          int16_t p1_y = (uint16_t((bytes[7] << 8) | bytes[6] ));
+          if ((bytes[7] & 0x80) >> 7){
+            p1_y -= pow(2, 15);
+          }else{
+            p1_y = 0 - p1_y;
+          }
+
+          float p1_speed = (bytes[9] << 8 | bytes[8] );
+          if ((bytes[9] & 0x80) >> 7){
+            p1_speed -= pow(2, 15);
+          }else{
+            p1_speed = 0 - p1_speed;
+          }
+          int16_t p1_distance_resolution = (uint16_t((bytes[11] << 8) | bytes[10] )); 
+
+          int16_t p2_x = (uint16_t((bytes[13] << 8) | bytes[12] ));
+          if ((bytes[13] & 0x80) >> 7){
+            p2_x -=  pow(2, 15); 
+          }else{
+            p2_x = 0 - p2_x;
+          }
+
+          int16_t p2_y = (uint16_t((bytes[15] << 8) | bytes[14] ));
+          if ((bytes[15] & 0x80) >> 7){
+            p2_y -= pow(2, 15);
+          }else{
+            p2_y = 0 - p2_y;
+          }
+
+          float p2_speed = (bytes[17] << 8 | bytes[16] );
+          if ((bytes[17] & 0x80) >> 7){
+            p2_speed -= pow(2, 15);
+          }else{
+            p2_speed = 0 - p2_speed;
+          }
+          int16_t p2_distance_resolution = (uint16_t((bytes[19] << 8) | bytes[18] )); 
+
+          int16_t p3_x = (uint16_t((bytes[21] << 8) | bytes[20] ));
+          if ((bytes[21] & 0x80) >> 7){
+            p3_x -=  pow(2, 15); 
+          }else{
+            p3_x = 0 - p3_x;
+          }
+
+          int16_t p3_y = (uint16_t((bytes[23] << 8) | bytes[22] ));
+          if ((bytes[23] & 0x80) >> 7){
+            p3_y -= pow(2, 15);
+          }else{
+            p3_y = 0 - p3_y;
+          }
+
+          float p3_speed = (bytes[25] << 8 | bytes[24] );
+          if ((bytes[25] & 0x80) >> 7){
+            p3_speed -= pow(2, 15);
+          }else{
+            p3_speed = 0 - p3_speed;
+          }
+          int16_t p3_distance_resolution = (uint16_t((bytes[27] << 8) | bytes[26] ));
+
+          const float RADIANS_TO_DEGREES = 180.0 / 3.14159265358979323846;
+          float p1_angle = atan2(p1_y, p1_x) * RADIANS_TO_DEGREES;
+          float p2_angle = atan2(p2_y, p2_x) * RADIANS_TO_DEGREES;
+          float p3_angle = atan2(p3_y, p3_x) * RADIANS_TO_DEGREES;
+          
+          float p1_distance = sqrt(p1_x * p1_x + p1_y * p1_y);
+          float p2_distance = sqrt(p2_x * p2_x + p2_y * p2_y);
+          float p3_distance = sqrt(p3_x * p3_x + p3_y * p3_y);
+          
+
+          float max_distance = float(id(distance).state) * 10;
+          if (p1_distance < max_distance) {
+            id(target1_x).publish_state(p1_x * -1);
+            id(target1_y).publish_state(p1_y);
+            id(target1_speed).publish_state(p1_speed / 100);
+            id(target1_resolution).publish_state(p1_distance_resolution);
+            id(target1_distance).publish_state(p1_distance);
+            id(target1_angle).publish_state(p1_angle - 90);
+          } else {
+            id(target1_x).publish_state(0);
+            id(target1_y).publish_state(0);
+            id(target1_speed).publish_state(0);
+            id(target1_resolution).publish_state(0);
+            id(target1_distance).publish_state(0);
+            id(target1_angle).publish_state(0);
+          }
+
+          if (p2_distance < max_distance) {
+            id(target2_x).publish_state(p2_x);
+            id(target2_y).publish_state(p2_y);
+            id(target2_speed).publish_state(p2_speed / 100);
+            id(target2_resolution).publish_state(p2_distance_resolution);
+            id(target2_distance).publish_state(p2_distance);
+            id(target2_angle).publish_state(p2_angle);
+          } else {
+            id(target2_x).publish_state(0);
+            id(target2_y).publish_state(0);
+            id(target2_speed).publish_state(0);
+            id(target2_resolution).publish_state(0);
+            id(target2_distance).publish_state(0);
+            id(target2_angle).publish_state(0);
+          }
+
+          if (p3_distance < max_distance) {
+            id(target3_x).publish_state(p3_x);
+            id(target3_y).publish_state(p3_y);
+            id(target3_speed).publish_state(p3_speed / 100);
+            id(target3_resolution).publish_state(p3_distance_resolution);
+            id(target3_distance).publish_state(p3_distance);
+            id(target3_angle).publish_state(p3_angle);
+          } else {
+            id(target3_x).publish_state(0);
+            id(target3_y).publish_state(0);
+            id(target3_speed).publish_state(0);
+            id(target3_resolution).publish_state(0);
+            id(target3_distance).publish_state(0);
+            id(target3_angle).publish_state(0);
+          }
+
+          int zone1_count = 0;      
+          if (id(target1_active).state == true ) {
+              if ((id(target1_x).state >= id(zone1_begin_x).state && id(target1_x).state <= id(zone1_end_x).state) &&
+                  (id(target1_y).state >= id(zone1_begin_y).state && id(target1_y).state <= id(zone1_end_y).state)) {
+                  zone1_count++;
+              }
+          }
+
+          if (id(target2_active).state == true ) {
+              if ((id(target2_x).state >= id(zone1_begin_x).state && id(target2_x).state <= id(zone1_end_x).state) &&
+                  (id(target2_y).state >= id(zone1_begin_y).state && id(target2_y).state <= id(zone1_end_y).state)) {
+                  zone1_count++;
+              }
+          }
+
+          if (id(target3_active).state == true ) {
+              if ((id(target3_x).state >= id(zone1_begin_x).state && id(target3_x).state <= id(zone1_end_x).state) &&
+                  (id(target3_y).state >= id(zone1_begin_y).state && id(target3_y).state <= id(zone1_end_y).state)) {
+                  zone1_count++;
+              }
+          }
+
+          if (zone1_count > 0) {
+              id(zone1_occupancy).publish_state(true);
+              id(zone1_target_count).publish_state(zone1_count);
+          } else {
+              id(zone1_occupancy).publish_state(false);
+              id(zone1_target_count).publish_state(0);
+          }
+
+          int zone2_count = 0;
+          if (id(target1_active).state == true ) {
+              if ((id(target1_x).state >= id(zone2_begin_x).state && id(target1_x).state <= id(zone2_end_x).state) &&
+                  (id(target1_y).state >= id(zone2_begin_y).state && id(target1_y).state <= id(zone2_end_y).state)) {
+                  zone2_count++;
+              }
+          }
+          if (id(target2_active).state == true ) {
+              if ((id(target2_x).state >= id(zone2_begin_x).state && id(target2_x).state <= id(zone2_end_x).state) &&
+                  (id(target2_y).state >= id(zone2_begin_y).state && id(target2_y).state <= id(zone2_end_y).state)) {
+                  zone2_count++;
+              }
+          }
+          if (id(target3_active).state == true ) {
+              if ((id(target3_x).state >= id(zone2_begin_x).state && id(target3_x).state <= id(zone2_end_x).state) &&
+                  (id(target3_y).state >= id(zone2_begin_y).state && id(target3_y).state <= id(zone2_end_y).state)) {
+                  zone2_count++;
+              }
+          }
+          if (zone2_count > 0) {
+              id(zone2_occupancy).publish_state(true);
+              id(zone2_target_count).publish_state(zone2_count);
+          } else {
+              id(zone2_occupancy).publish_state(false);
+              id(zone2_target_count).publish_state(0);
+          }
+
+          int zone3_count = 0;
+          if (id(target1_active).state == true ) {
+              if ((id(target1_x).state >= id(zone3_begin_x).state && id(target1_x).state <= id(zone3_end_x).state) &&
+                  (id(target1_y).state >= id(zone3_begin_y).state && id(target1_y).state <= id(zone3_end_y).state)) {
+                  zone3_count++;
+              }
+          }
+          if (id(target2_active).state == true ) {
+              if ((id(target2_x).state >= id(zone3_begin_x).state && id(target2_x).state <= id(zone3_end_x).state) &&
+                  (id(target2_y).state >= id(zone3_begin_y).state && id(target2_y).state <= id(zone3_end_y).state)) {
+                  zone3_count++;
+              }
+          }
+          if (id(target3_active).state == true ) {
+              if ((id(target3_x).state >= id(zone3_begin_x).state && id(target3_x).state <= id(zone3_end_x).state) &&
+                  (id(target3_y).state >= id(zone3_begin_y).state && id(target3_y).state <= id(zone3_end_y).state)) {
+                  zone3_count++;
+              }
+          }
+          if (zone3_count > 0) {
+              id(zone3_occupancy).publish_state(true);
+              id(zone3_target_count).publish_state(zone3_count);
+          } else {
+              id(zone3_occupancy).publish_state(false);
+              id(zone3_target_count).publish_state(0);
+          }
+
+          int zone4_count = 0;
+          if (id(target1_active).state == true ) {
+              if ((id(target1_x).state >= id(zone4_begin_x).state && id(target1_x).state <= id(zone4_end_x).state) &&
+                  (id(target1_y).state >= id(zone4_begin_y).state && id(target1_y).state <= id(zone4_end_y).state)) {
+                  zone4_count++;
+              }
+          }
+          if (id(target2_active).state == true ) {
+              if ((id(target2_x).state >= id(zone4_begin_x).state && id(target2_x).state <= id(zone4_end_x).state) &&
+                  (id(target2_y).state >= id(zone4_begin_y).state && id(target2_y).state <= id(zone4_end_y).state)) {
+                  zone4_count++;
+              }
+          }
+          if (id(target3_active).state == true ) {
+              if ((id(target3_x).state >= id(zone4_begin_x).state && id(target3_x).state <= id(zone4_end_x).state) &&
+                  (id(target3_y).state >= id(zone4_begin_y).state && id(target3_y).state <= id(zone4_end_y).state)) {
+                  zone4_count++;
+              }
+          }
+          if (zone4_count > 0) {
+              id(zone4_occupancy).publish_state(true);
+              id(zone4_target_count).publish_state(zone4_count);
+          } else {
+              id(zone4_occupancy).publish_state(false);
+              id(zone4_target_count).publish_state(0);
+          }
+          
+
+button:
+  - platform: restart
+    icon: mdi:power-cycle
+    name: "ESP Reboot"

--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -77,17 +77,25 @@ binary_sensor:
   - platform: template
     name: "Zone 1 Occupancy"
     id: zone1_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_1_off_delay).state *1000);
   - platform: template
     name: "Zone 2 Occupancy"
     id: zone2_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_2_off_delay).state *1000);
     disabled_by_default: true
   - platform: template
     name: "Zone 3 Occupancy"
     id: zone3_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_3_off_delay).state *1000);
     disabled_by_default: true
   - platform: template
     name: "Zone 4 Occupancy"
     id: zone4_occupancy
+    filters:
+      - delayed_off: !lambda return (id(zone_4_off_delay).state *1000);
     disabled_by_default: true
   - platform: template
     name: "Target 1 Active"
@@ -183,6 +191,16 @@ number:
     optimistic: True
     restore_value: True
     initial_value: 6000
+  - platform: template
+    name: "Zone 1 Occupancy Off Delay"
+    id: zone_1_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
 
   - platform: template
     name: "Zone 2 Begin X"
@@ -223,6 +241,17 @@ number:
     step: 10
     optimistic: True
     restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 2 Occupancy Off Delay"
+    id: zone_2_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
     disabled_by_default: true
 
   - platform: template
@@ -265,6 +294,17 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+  - platform: template
+    name: "Zone 3 Occupancy Off Delay"
+    id: zone_3_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
+    disabled_by_default: true
 
   - platform: template
     name: "Zone 4 Begin X"
@@ -305,6 +345,17 @@ number:
     step: 10
     optimistic: True
     restore_value: True
+    disabled_by_default: true
+  - platform: template
+    name: "Zone 4 Occupancy Off Delay"
+    id: zone_4_off_delay
+    max_value: 600
+    min_value: 0
+    step: 1
+    optimistic: True
+    restore_value: True
+    unit_of_measurement: "s"
+    initial_value: 15
     disabled_by_default: true
 
 sensor:


### PR DESCRIPTION
Adding a firmware option with bluetooth proxy disabled - this can be useful for performance reasons where Bluetooth Proxy can occasionally cause disconnects.