### PR TITLE
Add LD2410 Config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ on:
       - '**.yaml'
 
 jobs:
-  publish-everything-presence-lite:
-    name: Publish Everything Presence Lite
+  publish-everything-presence-lite-ha:
+    name: Publish Everything Presence Lite HA
     uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
     with:
       files: everything-presence-lite-ha.yaml
@@ -20,21 +20,32 @@ jobs:
       esphome_version: latest
       directory_name: everything-presence-lite-ha
   publish-everything-presence-lite-ha-no-ble:
-    name: Publish Everything Presence Lite No BLE
+    name: Publish Everything Presence Lite HA No BLE
     uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
     with:
       files: everything-presence-lite-ha-no-ble.yaml
-      name: Everything Presence Lite No BLE
+      name: Everything Presence Lite HA No BLE
       manifest_filename: everything-presence-lite-ha-no-ble-manifest.json
       clean: false
       esphome_version: latest
       directory_name: everything-presence-lite-ha-no-ble
-#  publish-everything-presence-one-ha-beta:
-#    name: Publish Everything Presence One Home Assistant Beta
-#    uses: esphome/workflows/.github/workflows/publish.yml@main
-#    with:
-#      files: everything-presence-one-beta.yaml
-#      name: Everything Presence One HA Beta
-#      manifest_filename: everything-presence-one-ha-beta-manifest.json
-#      clean: false
-#      esphome_version: latest
+  publish-everything-presence-lite-ha-ld2410:
+    name: Publish Everything Presence Lite HA LD2410
+    uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
+    with:
+      files: everything-presence-lite-ha-ld2410.yaml
+      name: Everything Presence Lite HA LD2410
+      manifest_filename: everything-presence-lite-ha-ld2410-manifest.json
+      clean: false
+      esphome_version: latest
+      directory_name: everything-presence-lite-ha-ld2410
+  publish-everything-presence-lite-ha-ld2410-no-ble:
+    name: Publish Everything Presence Lite HA LD2410 No BLE
+    uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
+    with:
+      files: everything-presence-lite-ha-ld2410-no-ble.yaml
+      name: Everything Presence Lite HA LD2410 No BLE
+      manifest_filename: everything-presence-lite-ha-ld2410-no-ble-manifest.json
+      clean: false
+      esphome_version: latest
+      directory_name: everything-presence-lite-ha-ld2410-no-ble

--- a/common/ld2410-base.yaml
+++ b/common/ld2410-base.yaml
@@ -1,0 +1,189 @@
+esphome:
+  on_boot:
+    then:
+      - switch.turn_on: engineering_mode
+
+uart:
+  id: uart_bus
+  baud_rate:  256000
+  rx_pin: 16
+  tx_pin: 17
+  parity: NONE
+  stop_bits: 1
+
+ld2410:
+
+binary_sensor:
+  - platform: ld2410
+    has_target:
+      name: Occupancy
+    has_moving_target:
+      name: Moving Target
+    has_still_target:
+      name: Still Target
+  - platform: gpio
+    pin: 18
+    name: Occupancy
+    device_class: Occupancy
+
+sensor:
+  - platform: ld2410
+    light:
+      name: mmWave Light
+      disabled_by_default: true
+    moving_distance:
+      name: Moving Target Distance
+    still_distance:
+      name: Still Target Distance
+    moving_energy:
+      name: Moveing Target Energy
+    still_energy:
+      name: Still Target Energy
+    detection_distance:
+      name: Detection Distance
+    g0:
+      move_energy:
+        name: Gate 0 Movement Energy
+      still_energy:
+        name: Gate 0 Still Energy
+    g1:
+      move_energy:
+        name: Gate 1 Movement Energy
+      still_energy:
+        name: Gate 1 Still Energy
+    g2:
+      move_energy:
+        name: Gate 2 Movement Energy
+      still_energy:
+        name: Gate 2 Still Energy
+    g3:
+      move_energy:
+        name: Gate 3 Movement Energy
+      still_energy:
+        name: Gate 3 Still Energy
+    g4:
+      move_energy:
+        name: Gate 4 Movement Energy
+      still_energy:
+        name: Gate 4 Still Energy
+    g5:
+      move_energy:
+        name: Gate 5 Movement Energy
+      still_energy:
+        name: Gate 5 Still Energy
+    g6:
+      move_energy:
+        name: Gate 6 Movement Energy
+      still_energy:
+        name: Gate 6 Still Energy
+    g7:
+      move_energy:
+        name: Gate 7 Movement Energy
+      still_energy:
+        name: Gate 7 Still Energy
+    g8:
+      move_energy:
+        name: Gate 8 Movement Energy
+      still_energy:
+        name: Gate 8 Still Energy
+
+switch:
+  - platform: ld2410
+    engineering_mode:
+      name: "Engineering Mode"
+      id: "engineering_mode"
+    bluetooth:
+      name: "mmWave Bluetooth"
+      disabled_by_default: true
+
+number:
+  - platform: ld2410
+    timeout:
+      name: Occupancy Off Delay
+    light_threshold:
+      name: mmWave Light Threshold
+      disabled_by_default: True
+    max_move_distance_gate:
+      name: Max Movement Distance Gate
+    max_still_distance_gate:
+      name: Max Still Distance Gate
+    g0:
+      move_threshold:
+        name: Gate 0 Movement Sensitivity
+      still_threshold:
+        name: Gate 0 Still Sensitivity
+    g1:
+      move_threshold:
+        name: Gate 1 Movement Sensitivity
+      still_threshold:
+        name: Gate 1 Still Sensitivity
+    g2:
+      move_threshold:
+        name: Gate 2 Movement Sensitivity
+      still_threshold:
+        name: Gate 2 Still Sensitivity
+    g3:
+      move_threshold:
+        name: Gate 3 Movement Sensitivity
+      still_threshold:
+        name: Gate 3 Still Sensitivity
+    g4:
+      move_threshold:
+        name: Gate 4 Movement Sensitivity
+      still_threshold:
+        name: Gate 4 Still Sensitivity
+    g5:
+      move_threshold:
+        name: Gate 5 Movement Sensitivity
+      still_threshold:
+        name: Gate 5 Still Sensitivity
+    g6:
+      move_threshold:
+        name: Gate 6 Movement Sensitivity
+      still_threshold:
+        name: Gate 6 Still Sensitivity
+    g7:
+      move_threshold:
+        name: Gate 7 Movement Sensitivity
+      still_threshold:
+        name: Gate 7 Still Sensitivity
+    g8:
+      move_threshold:
+        name: Gate 8 Movement Sensitivity
+      still_threshold:
+        name: Gate 8 Still Sensitivity
+
+button:
+  - platform: ld2410
+    factory_reset:
+      name: "Factory Reset mmWave"
+      disabled_by_default: true
+    restart:
+      name: "Restart mmWave"
+      disabled_by_default: true
+    query_params:
+      name: Get Values
+      disabled_by_default: true
+
+text_sensor:
+  - platform: ld2410
+    version:
+      name: "mmWave Firmware Version"
+    mac_address:
+      name: "mmWave MAC Address"
+      disabled_by_default: true
+
+select:
+  - platform: ld2410
+    distance_resolution:
+      name: "Distance Gate Resolution"
+      disabled_by_default: true
+    baud_rate:
+      name: "mmWave Sensor Baud Rate"
+      disabled_by_default: true
+    light_function:
+      name: mmWave Light Function
+      disabled_by_default: true
+    out_pin_level:
+      name: GPIO Pin Level
+      disabled_by_default: true

--- a/everything-presence-lite-ha-ld2410-no-ble.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble.yaml
@@ -1,0 +1,14 @@
+substitutions:
+  name: "everything-presence-lite"
+  friendly_name: "Everything Presence Lite"
+  illuminance_update_interval: "2s"
+  hidden_ssid: "false"
+  log_level: ERROR
+
+dashboard_import:
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble.yaml@main
+  import_full_config: false # or true
+
+packages:
+  device_base: !include common/everything-presence-lite-base.yaml
+  ld2450_base: !include common/ld2410-base.yaml

--- a/everything-presence-lite-ha-ld2410.yaml
+++ b/everything-presence-lite-ha-ld2410.yaml
@@ -1,0 +1,15 @@
+substitutions:
+  name: "everything-presence-lite"
+  friendly_name: "Everything Presence Lite"
+  illuminance_update_interval: "2s"
+  hidden_ssid: "false"
+  log_level: ERROR
+
+dashboard_import:
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410.yaml@main
+  import_full_config: false # or true
+
+packages:
+  device_base: !include common/everything-presence-lite-base.yaml
+  ld2450_base: !include common/ld2410-base.yaml
+  bluetooth_base: !include common/bluetooth-base.yaml


### PR DESCRIPTION
Adds BLE and non BLE configs for the LD2410 mmWave sensor for use with the Everything Presence Lite.