### PR TITLE
Add SEN0395 Sensor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,3 +49,23 @@ jobs:
       clean: false
       esphome_version: latest
       directory_name: everything-presence-lite-ha-ld2410-no-ble
+  publish-everything-presence-lite-ha-sen0395:
+    name: Publish Everything Presence Lite HA SEN0395
+    uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
+    with:
+      files: everything-presence-lite-ha-sen0395.yaml
+      name: Everything Presence Lite HA SEN0395
+      manifest_filename: everything-presence-lite-ha-sen0395-manifest.json
+      clean: false
+      esphome_version: latest
+      directory_name: everything-presence-lite-ha-sen0395
+  publish-everything-presence-lite-ha-sen0395-no-ble:
+    name: Publish Everything Presence Lite HA SEN0395 No BLE
+    uses: EverythingSmartHome/everything-presence-lite/.github/workflows/esphome-build.yml@main
+    with:
+      files: everything-presence-lite-ha-sen0395-no-ble.yaml
+      name: Everything Presence Lite HA SEN0395 No BLE
+      manifest_filename: everything-presence-lite-ha-sen0395-no-ble-manifest.json
+      clean: false
+      esphome_version: latest
+      directory_name: everything-presence-lite-ha-sen0395-no-ble

--- a/common/sen0395-base.yaml
+++ b/common/sen0395-base.yaml
@@ -1,0 +1,230 @@
+light:
+  - platform: binary
+    name: mmWave LED
+    restore_mode: RESTORE_DEFAULT_OFF
+    output: mmwave_led_output
+    entity_category: config
+    disabled_by_default: False
+
+output:
+  - platform: template
+    id: mmwave_led_output
+    type: binary
+    write_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - if:
+          condition:
+            lambda: !lambda return state;
+          then:
+            - uart.write: "setLedMode 1 0"
+          else:
+            - uart.write: "setLedMode 1 1"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
+
+binary_sensor:
+  - platform: gpio
+    name: Occupancy
+    id: mmwave
+    device_class: occupancy
+    pin:
+      number: GPIO19
+      mode: INPUT_PULLDOWN
+
+uart:
+  id: uart_bus
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+  debug:
+    direction: BOTH
+    dummy_receiver: true
+    after:
+      delimiter: "\n"
+    sequence:
+      - lambda: UARTDebug::log_string(direction, bytes);
+
+switch:
+  - platform: template
+    name: mmWave sensor
+    id: mmwave_sensor
+    disabled_by_default: True
+    entity_category: config
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+    turn_on_action:
+      - uart.write: "sensorStart"
+      - delay: 1s
+    turn_off_action:
+      - uart.write: "sensorStop"
+      - delay: 1s
+
+  - platform: template
+    name: UART presence output
+    id: uart_presence_output
+    entity_category: config
+    disabled_by_default: true
+    optimistic: true
+    turn_on_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: "setUartOutput 1 1"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
+    turn_off_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: "setUartOutput 1 0"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
+
+  - platform: template
+    name: UART target output
+    id: uart_target_output
+    entity_category: config
+    disabled_by_default: true
+    optimistic: true
+    assumed_state: false
+    turn_on_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: "setUartOutput 2 1 1 1"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
+    turn_off_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: "setUartOutput 2 0"
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor
+
+number:
+  - platform: template
+    id: mmwave_distance
+    name: mmWave distance
+    icon: mdi:arrow-left-right
+    entity_category: config
+    min_value: 0
+    max_value: 800
+    initial_value: 315
+    optimistic: true
+    step: 15
+    restore_value: true
+    unit_of_measurement: cm
+    mode: slider
+    set_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: !lambda int cm = (int)ceil(x / 15.0);
+          std::string cms = "detRangeCfg -1 0 " + to_string(cm);
+          return std::vector<unsigned char>(cms.begin(), cms.end());
+      - delay: 1s
+      - uart.write: "saveCfg 0x45670123 0xCDEF89AB 0x956128C6 0xDF54AC89"
+      - delay: 1s
+      - switch.turn_on: mmwave_sensor
+
+  - platform: template
+    name: mmWave off latency
+    icon: mdi:clock-end
+    entity_category: config
+    id: mmwave_off_latency
+    min_value: 1
+    max_value: 600
+    initial_value: 15
+    optimistic: true
+    step: 5
+    restore_value: true
+    unit_of_measurement: seconds
+    mode: slider
+    set_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: !lambda |-
+          std::string mss = "setLatency " + to_string(id(mmwave_on_latency).state) + " " + to_string(id(mmwave_off_latency).state);
+          return std::vector<unsigned char>(mss.begin(), mss.end());
+      - delay: 1s
+      - uart.write: "saveCfg 0x45670123 0xCDEF89AB 0x956128C6 0xDF54AC89"
+      - delay: 1s
+      - switch.turn_on: mmwave_sensor
+
+  - platform: template
+    name: mmWave on latency
+    icon: mdi:clock-start
+    id: mmwave_on_latency
+    entity_category: config
+    min_value: 0
+    max_value: 2
+    initial_value: 0
+    optimistic: true
+    step: 0.25
+    restore_value: true
+    unit_of_measurement: seconds
+    mode: slider
+    set_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: !lambda |-
+          std::string mss = "setLatency " + to_string(id(mmwave_on_latency).state) + " " + to_string(id(mmwave_off_latency).state);
+          return std::vector<unsigned char>(mss.begin(), mss.end());
+      - delay: 1s
+      - uart.write: "saveCfg 0x45670123 0xCDEF89AB 0x956128C6 0xDF54AC89"
+      - delay: 1s
+      - switch.turn_on: mmwave_sensor
+
+  - platform: template
+    name: mmWave sensitivity
+    icon: mdi:target-variant
+    id: mmwave_sensitivity
+    entity_category: config
+    min_value: 0
+    max_value: 9
+    initial_value: 7
+    optimistic: true
+    step: 1
+    restore_value: true
+    set_action:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write:
+          !lambda std::string mss = "setSensitivity " + to_string((int)x);
+          return std::vector<unsigned char>(mss.begin(), mss.end());
+      - delay: 1s
+      - uart.write: "saveConfig"
+      - delay: 1s
+      - switch.turn_on: mmwave_sensor
+
+button:
+  - platform: restart
+    id: restart_internal
+    entity_category: config
+    internal: true
+  - platform: template
+    name: Restart mmWave Sensor
+    id: restart_mmwave
+    entity_category: config
+    internal: true
+    on_press:
+      - uart.write: "resetSystem"
+  - platform: template
+    name: Factory Reset mmWave
+    icon: mdi:cog-counterclockwise
+    id: factory_reset_mmwave
+    disabled_by_default: true
+    entity_category: config
+    on_press:
+      - switch.turn_off: mmwave_sensor
+      - delay: 1s
+      - uart.write: "resetCfg"
+      - delay: 3s
+      - switch.turn_on: mmwave_sensor

--- a/everything-presence-lite-ha-sen0395-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble.yaml
@@ -1,0 +1,14 @@
+substitutions:
+  name: "everything-presence-lite"
+  friendly_name: "Everything Presence Lite"
+  illuminance_update_interval: "2s"
+  hidden_ssid: "false"
+  log_level: ERROR
+
+dashboard_import:
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble.yaml@main
+  import_full_config: false # or true
+
+packages:
+  device_base: !include common/everything-presence-lite-base.yaml
+  ld2450_base: !include common/sen0395-base.yaml

--- a/everything-presence-lite-ha-sen0395.yaml
+++ b/everything-presence-lite-ha-sen0395.yaml
@@ -1,0 +1,15 @@
+substitutions:
+  name: "everything-presence-lite"
+  friendly_name: "Everything Presence Lite"
+  illuminance_update_interval: "2s"
+  hidden_ssid: "false"
+  log_level: ERROR
+
+dashboard_import:
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395.yaml@main
+  import_full_config: false # or true
+
+packages:
+  device_base: !include common/everything-presence-lite-base.yaml
+  ld2450_base: !include common/sen0395-base.yaml
+  bluetooth_base: !include common/bluetooth-base.yaml


### PR DESCRIPTION
This PR adds config support for the DFRobot  SEN0395 (same sensor as is in the EP1) to use with the Everything Presence Lite