### PR TITLE
Fix target 1 displaying a negative value

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: True
   project: 
     name: EverythingSmartTechnology.Everything Presence Lite
-    version: "1.0.2"
+    version: "1.0.3"
 
 esp32:
   board: esp32dev

--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -478,7 +478,6 @@ uart:
           }else{
             p1_x = 0 - p1_x; // was 0 - p1_x;
           }
-          p1_x = -p1_x;
 
           int16_t p1_y = (uint16_t((bytes[7] << 8) | bytes[6] ));
           if ((bytes[7] & 0x80) >> 7){


### PR DESCRIPTION
Fixes an issue where target 1 would show an incorrect negative value compared to target 2 and target 3 in the same position showing postive values.