### PR TITLE
Add firmware update entity

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: True
   project: 
     name: EverythingSmartTechnology.Everything Presence Lite
-    version: "1.0.3"
+    version: "1.0.4"
 
 esp32:
   board: esp32dev
@@ -20,7 +20,10 @@ logger:
 api:
 
 ota:
-  platform: esphome
+  - platform: esphome
+    id: ota_esphome
+  - platform: http_request
+    id: ota_http_request
 
 wifi:
 

--- a/everything-presence-lite-ha-ld2410-no-ble.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-ld2410.yaml
+++ b/everything-presence-lite-ha-ld2410.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-mr24hpc1.yaml
+++ b/everything-presence-lite-ha-mr24hpc1.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-no-ble.yaml
+++ b/everything-presence-lite-ha-no-ble.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: DEBUG
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-sen0395-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-sen0395.yaml
+++ b/everything-presence-lite-ha-sen0395.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-sen0609-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0609-no-ble.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha-sen0609.yaml
+++ b/everything-presence-lite-ha-sen0609.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: ERROR
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609.yaml@main
   import_full_config: false # or true

--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -5,6 +5,12 @@ substitutions:
   hidden_ssid: "false"
   log_level: DEBUG
 
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-manifest.json
+
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha.yaml@main
   import_full_config: false # or true


### PR DESCRIPTION
Adds the new update mechanism to all firmwares. This will show a new update entity in Home Assistant, letting you directly update the firmware of the Lite directly from the builds published on GitHub