### PR TITLE
remove unnecessary fencing interfering with delayed_off

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: True
   project: 
     name: EverythingSmartTechnology.Everything Presence Lite
-    version: "1.0.7"
+    version: "1.0.8"
 
 esp32:
   board: esp32dev

--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -769,13 +769,11 @@ uart:
           }
 
           if (zone1_count > 0) {
-            if (id(zone1_occupancy).state != true)
-              id(zone1_occupancy).publish_state(true);
+            id(zone1_occupancy).publish_state(true);
             if (id(zone1_target_count).state != zone1_count)
               id(zone1_target_count).publish_state(zone1_count);
           } else {
-            if (id(zone1_occupancy).state != false)
-              id(zone1_occupancy).publish_state(false);
+            id(zone1_occupancy).publish_state(false);
             if (id(zone1_target_count).state != 0)
               id(zone1_target_count).publish_state(0);
           }
@@ -800,13 +798,11 @@ uart:
               }
           }
           if (zone2_count > 0) {
-            if (id(zone2_occupancy).state != true)
-              id(zone2_occupancy).publish_state(true);
+            id(zone2_occupancy).publish_state(true);
             if (id(zone2_target_count).state != zone2_count)
               id(zone2_target_count).publish_state(zone2_count);
           } else {
-            if (id(zone2_occupancy).state != false)
-              id(zone2_occupancy).publish_state(false);
+            id(zone2_occupancy).publish_state(false);
             if (id(zone2_target_count).state != 0)
               id(zone2_target_count).publish_state(0);
           }
@@ -831,13 +827,11 @@ uart:
               }
           }
           if (zone3_count > 0) {
-            if (id(zone3_occupancy).state != true)
-              id(zone3_occupancy).publish_state(true);
+            id(zone3_occupancy).publish_state(true);
             if (id(zone3_target_count).state != zone3_count)
               id(zone3_target_count).publish_state(zone3_count);
           } else {
-            if (id(zone3_occupancy).state != false)
-              id(zone3_occupancy).publish_state(false);
+            id(zone3_occupancy).publish_state(false);
             if (id(zone3_target_count).state != 0)
               id(zone3_target_count).publish_state(0);
           }
@@ -862,13 +856,11 @@ uart:
               }
           }
           if (zone4_count > 0) {
-            if (id(zone4_occupancy).state != true)
-              id(zone4_occupancy).publish_state(true);
+            id(zone4_occupancy).publish_state(true);
             if (id(zone4_target_count).state != zone4_count)
               id(zone4_target_count).publish_state(zone4_count);
           } else {
-            if (id(zone4_occupancy).state != false)
-              id(zone4_occupancy).publish_state(false);
+            id(zone4_occupancy).publish_state(false);
             if (id(zone4_target_count).state != 0)
               id(zone4_target_count).publish_state(0);
           }


### PR DESCRIPTION
As the check for the state returns true as long as the delayed_off time has not passed it will not trigger a publish_state that will reset the delay time. This results in the occupancy turning off after the delay_time has passed and immediately turns back on in the next cycle as the publish_state is not fenced anymore.

To fix this I simply removed the check for the state before the state is published as esphome already has deduplication built in for binary sensors (see [binary_sensor.cpp#L15](https://github.com/esphome/esphome/blob/07b78fea760e78e5be5c0dbbf506f2fca490cff0/esphome/components/binary_sensor/binary_sensor.cpp#L15))