### PR TITLE
Fix bootloop when internet blocked

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: True
   project: 
     name: EverythingSmartTechnology.Everything Presence Lite
-    version: "1.0.6"
+    version: "1.0.7"
 
 esp32:
   board: esp32dev
@@ -26,6 +26,7 @@ ota:
     id: ota_http_request
 
 http_request:
+  timeout: 4s
 
 wifi:
 


### PR DESCRIPTION
Fix Everything Presence Lite from boot looping when the internet is blocked from the device. This was a bug in ESPHome 2024.7.1 and will be fixed in ESPHome 2024.7.2, but this workaround also resolves it for now.