### PR TITLE
Disable manufacturer update by default

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -26,7 +26,6 @@ ota:
     id: ota_http_request
 
 http_request:
-  timeout: 4s
 
 wifi:
 

--- a/everything-presence-lite-ha-ld2410-no-ble.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble.yaml@main

--- a/everything-presence-lite-ha-ld2410.yaml
+++ b/everything-presence-lite-ha-ld2410.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1.yaml
+++ b/everything-presence-lite-ha-mr24hpc1.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1.yaml@main

--- a/everything-presence-lite-ha-no-ble.yaml
+++ b/everything-presence-lite-ha-no-ble.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble.yaml@main

--- a/everything-presence-lite-ha-sen0395-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble.yaml@main

--- a/everything-presence-lite-ha-sen0395.yaml
+++ b/everything-presence-lite-ha-sen0395.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395.yaml@main

--- a/everything-presence-lite-ha-sen0609-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0609-no-ble.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble.yaml@main

--- a/everything-presence-lite-ha-sen0609.yaml
+++ b/everything-presence-lite-ha-sen0609.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609.yaml@main

--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -8,8 +8,9 @@ substitutions:
 update:
   - platform: http_request
     id: update_http_request
-    name: Firmware
+    name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-manifest.json
+    disabled_by_default: true
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha.yaml@main


### PR DESCRIPTION
This changes the new manufacturer update entity to disabled by default, so that it is hidden. This is due to many users getting confused at the difference between the ESPHome update entity and the new manufacturer update entity. This has caused them to overwrite their encryption key and thus Home Assistant isn't able to communicate with the device.

Until their is a better way to handle the manufacturer updates when an encryption key is set, I will disable it for now to not cause so much confusion.

It also removes the http_request timeout that was set in a previous version to help with an esphome bug. The timeout in ESPHome is now 4.5s by default.