### PR TITLE
Add zone target count unit of measure

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -538,21 +538,26 @@ sensor:
     name: "Zone 1 Target Count"
     id: zone1_target_count
     accuracy_decimals: 0
+    unit_of_measurement: " "
   - platform: template
     name: "Zone 2 Target Count"
     id: zone2_target_count
     accuracy_decimals: 0
     disabled_by_default: true
+    unit_of_measurement: " "
   - platform: template
     name: "Zone 3 Target Count"
     id: zone3_target_count
     accuracy_decimals: 0
     disabled_by_default: true
+    unit_of_measurement: " "
   - platform: template
     name: "Zone 4 Target Count"
     id: zone4_target_count
     accuracy_decimals: 0
     disabled_by_default: true
+    unit_of_measurement: " "
+
 
 uart:
   id: uart_bus


### PR DESCRIPTION
Allows home assistant's History graph to show occupancy count as a number
<img width="1142" alt="Screenshot 2024-09-04 at 11 48 00 PM" src="https://github.com/user-attachments/assets/d718bda7-b8c1-4dc4-9048-7aaf13d8fd97">
