### PR TITLE
Update troubleshooting.md

### DIFF
--- a/static/troubleshooting.md
+++ b/static/troubleshooting.md
@@ -28,4 +28,9 @@ No, it will only show a detected or not detected status.
 **I prefer to 3D print my own case** No worries you can find the files you need here [https://www.printables.com/model/624830-everything-presence-lite-official-case](https://www.printables.com/model/624830-everything-presence-lite-official-case "https://www.printables.com/model/624830-everything-presence-lite-official-case")
 
 **My EPL stops updating occupancy after some time, light levels are still reported fine.**
-There was a problem with an earlier firmware of the radar sensor used by the EPL which can cause a loss of communication until powercycling the whole device. Try updating the radar sensor over bluetooth via the manufacturers app [Android](https://play.google.com/store/apps/details?id=com.hlk.hlkradartool)/[iOS](https://apps.apple.com/us/app/hlkradartool/id1638651152) to at least version 2.04. Be aware that the update app seems to be very unstable and you might need multiple tries or an Android device as it seems a bit more stable there. 
+There was a problem with earlier firmware versions of the LD2450 mmWave sensor used by the EPL which can cause a loss of communication until power-cycling the whole device.
+
+1. In Home Assistant, enable the mmWave Bluetooth entity if disabled, then toggle it **ON**.
+2. Install and open Hi-Link's HLKRadarTool app [Android](https://play.google.com/store/apps/details?id=com.hlk.hlkradartool)/[iOS](https://apps.apple.com/us/app/hlkradartool/id1638651152), stand physically close to the EPL, then connect to the LD2450 and perform an OTA firmware update to at least version 2.04.23101915
+3. If the iOS version of HLKRadarTool crashes, try [RadarTools](https://apps.apple.com/gb/app/radartools/id6502672452) instead
+4. In Home Assistant, toggle the mmWave Bluetooth entity **OFF** to prevent unauthorised access to the LD2450 and disable the entity if it's no longer needed


### PR DESCRIPTION
* Clarify precise working version of LD2450 firmware
* Add link to RadarTools iOS app as HLKRadarTool is unstable when connecting to an LD2450 running earlier firmware versions (it crashes before showing the OTA update)