### PR TITLE
Revert illuminance calibration

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -68,22 +68,6 @@ sensor:
     address: 0x23
     update_interval: ${illuminance_update_interval}
     filters:
-      - calibrate_linear:
-          method: exact
-          datapoints:
-            - 0.6 -> 1.7
-            - 9 -> 25
-            - 10 -> 29
-            - 14 -> 367
-            - 19 -> 26
-            - 21 -> 885
-            - 22 -> 88
-            - 29 -> 52
-            - 85 -> 166 
-            - 283 -> 394
-            - 807 -> 993
-            - 917 -> 1124
-            - 1132 -> 1170
       - lambda: "return x + id(illuminance_offset_ui).state;"
       - clamp:
           min_value: 0


### PR DESCRIPTION
Reverts changes made in https://github.com/EverythingSmartHome/everything-presence-lite/pull/116

Some users have issue where an increase in light level will report a lower value - reverting until a more stable method can be found.