### PR TITLE
Fix false zone trigger

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -756,21 +756,21 @@ uart:
           }
 
           int zone1_count = 0;      
-          if (id(target1_active).state == true ) {
+          if (p1_distance > 0 ) {
               if ((id(target1_x).state >= id(zone1_begin_x).state && id(target1_x).state <= id(zone1_end_x).state) &&
                   (id(target1_y).state >= id(zone1_begin_y).state && id(target1_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
               }
           }
 
-          if (id(target2_active).state == true ) {
+          if (p2_distance > 0 ) {
               if ((id(target2_x).state >= id(zone1_begin_x).state && id(target2_x).state <= id(zone1_end_x).state) &&
                   (id(target2_y).state >= id(zone1_begin_y).state && id(target2_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
               }
           }
 
-          if (id(target3_active).state == true ) {
+          if (p3_distance > 0 ) {
               if ((id(target3_x).state >= id(zone1_begin_x).state && id(target3_x).state <= id(zone1_end_x).state) &&
                   (id(target3_y).state >= id(zone1_begin_y).state && id(target3_y).state <= id(zone1_end_y).state)) {
                   zone1_count++;
@@ -788,19 +788,19 @@ uart:
           }
 
           int zone2_count = 0;
-          if (id(target1_active).state == true ) {
+          if (p1_distance > 0 ) {
               if ((id(target1_x).state >= id(zone2_begin_x).state && id(target1_x).state <= id(zone2_end_x).state) &&
                   (id(target1_y).state >= id(zone2_begin_y).state && id(target1_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (p2_distance > 0 ) {
               if ((id(target2_x).state >= id(zone2_begin_x).state && id(target2_x).state <= id(zone2_end_x).state) &&
                   (id(target2_y).state >= id(zone2_begin_y).state && id(target2_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (p3_distance > 0 ) {
               if ((id(target3_x).state >= id(zone2_begin_x).state && id(target3_x).state <= id(zone2_end_x).state) &&
                   (id(target3_y).state >= id(zone2_begin_y).state && id(target3_y).state <= id(zone2_end_y).state)) {
                   zone2_count++;
@@ -817,19 +817,19 @@ uart:
           }
 
           int zone3_count = 0;
-          if (id(target1_active).state == true ) {
+          if (p1_distance > 0 ) {
               if ((id(target1_x).state >= id(zone3_begin_x).state && id(target1_x).state <= id(zone3_end_x).state) &&
                   (id(target1_y).state >= id(zone3_begin_y).state && id(target1_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (p2_distance > 0 ) {
               if ((id(target2_x).state >= id(zone3_begin_x).state && id(target2_x).state <= id(zone3_end_x).state) &&
                   (id(target2_y).state >= id(zone3_begin_y).state && id(target2_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (p3_distance > 0 ) {
               if ((id(target3_x).state >= id(zone3_begin_x).state && id(target3_x).state <= id(zone3_end_x).state) &&
                   (id(target3_y).state >= id(zone3_begin_y).state && id(target3_y).state <= id(zone3_end_y).state)) {
                   zone3_count++;
@@ -846,19 +846,19 @@ uart:
           }
 
           int zone4_count = 0;
-          if (id(target1_active).state == true ) {
+          if (p1_distance > 0 ) {
               if ((id(target1_x).state >= id(zone4_begin_x).state && id(target1_x).state <= id(zone4_end_x).state) &&
                   (id(target1_y).state >= id(zone4_begin_y).state && id(target1_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;
               }
           }
-          if (id(target2_active).state == true ) {
+          if (p2_distance > 0 ) {
               if ((id(target2_x).state >= id(zone4_begin_x).state && id(target2_x).state <= id(zone4_end_x).state) &&
                   (id(target2_y).state >= id(zone4_begin_y).state && id(target2_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;
               }
           }
-          if (id(target3_active).state == true ) {
+          if (p3_distance > 0 ) {
               if ((id(target3_x).state >= id(zone4_begin_x).state && id(target3_x).state <= id(zone4_end_x).state) &&
                   (id(target3_y).state >= id(zone4_begin_y).state && id(target3_y).state <= id(zone4_end_y).state)) {
                   zone4_count++;


### PR DESCRIPTION
Fixes an issue where a zone could be triggered when a target is lost and X and Y coordinates reset to 0, if a zones boundaries include 0 coordinates.