### PR TITLE
Allow scaling of illuminance values

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -62,6 +62,22 @@ number:
     on_value:
       - lambda: 'id(illuminance_sensor).update();'
 
+  - platform: template
+    name: "Illuminance Scale"
+    id: illuminance_scale_ui
+    min_value: 0.01
+    max_value: 10.0
+    step: 0.01
+    update_interval: never
+    optimistic: true
+    restore_value: true
+    initial_value: 1.0
+    icon: "mdi:contrast-circle"
+    entity_category: config
+    disabled_by_default: true
+    on_value:
+      - lambda: 'id(illuminance_sensor).update();'
+
 sensor:
   - platform: bh1750
     name: Illuminance
@@ -70,7 +86,7 @@ sensor:
     address: 0x23
     update_interval: ${illuminance_update_interval}
     filters:
-      - lambda: "return x + id(illuminance_offset_ui).state;"
+      - lambda: "return x*id(illuminance_scale_ui).state + id(illuminance_offset_ui).state;"
       - clamp:
           min_value: 0
 


### PR DESCRIPTION
Following up on the discussion about luminance calibration from a few weeks back, this PR presents the modification I've been using in my own deployment (rebased against the current HEAD, which no longer includes the calibration table).

This adds a (default disabled) entity containing a scaling value for the luminance sensor, which multiplies the luminance value from the hardware sensor in the same way as the other configuration entity adds to it to provide an offset. This means that you can scale the hardware sensor up or down to match an external reference or to compensate for variation between sensors.

In practice, I've found that the sensor value is in any case quite dependent on the exact placement of the EPL, because the sensor is inside the case but just under a slot in the top. So if the light is mainly coming from above, you don't need much compensation but the same light coming from a different direction (or if the EPL faces in a different direction) might need a tweak.

So this is probably largely cosmetic, but I thought some people might find it useful.