### PR TITLE
Add occupancy mask

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -174,6 +174,26 @@ binary_sensor:
     name: "Target 3 Active"
     id: target3_active
 
+  - platform: template
+    name: "Target 1 Masked"
+    id: target1_masked
+    lambda: |-
+      return (id(target1_x).state >= id(occupancy_mask_1_begin_x).state && id(target1_x).state <= id(occupancy_mask_1_end_x).state && 
+              id(target1_y).state >= id(occupancy_mask_1_begin_y).state && id(target1_y).state <= id(occupancy_mask_1_end_y).state);
+  - platform: template
+    name: "Target 2 Masked"
+    id: target2_masked
+    lambda: |-
+      return (id(target2_x).state >= id(occupancy_mask_1_begin_x).state && id(target2_x).state <= id(occupancy_mask_1_end_x).state && 
+              id(target2_y).state >= id(occupancy_mask_1_begin_y).state && id(target2_y).state <= id(occupancy_mask_1_end_y).state);
+  - platform: template
+    name: "Target 3 Masked"
+    id: target3_masked
+    lambda: |-
+      return (id(target3_x).state >= id(occupancy_mask_1_begin_x).state && id(target3_x).state <= id(occupancy_mask_1_end_x).state && 
+              id(target3_y).state >= id(occupancy_mask_1_begin_y).state && id(target3_y).state <= id(occupancy_mask_1_end_y).state);
+
+
 number:
   - platform: template
     name: "Occupancy Off Delay"
@@ -415,6 +435,47 @@ number:
     unit_of_measurement: "s"
     initial_value: 15
     disabled_by_default: true
+
+  - platform: template
+    name: "Occupancy Mask 1 Begin X"
+    id: occupancy_mask_1_begin_x
+    max_value: 6000
+    min_value: -6000
+    unit_of_measurement: "mm"
+    step: 10
+    entity_category: config
+    optimistic: True
+    restore_value: True
+  - platform: template
+    name: "Occupancy Mask 1 End X"
+    id: occupancy_mask_1_end_x
+    max_value: 6000
+    min_value: -6000
+    unit_of_measurement: "mm"
+    step: 10
+    entity_category: config
+    optimistic: True
+    restore_value: True
+  - platform: template
+    name: "Occupancy Mask 1 Begin Y"
+    id: occupancy_mask_1_begin_y
+    max_value: 6000
+    min_value: -1560
+    unit_of_measurement: "mm"
+    step: 10
+    entity_category: config
+    optimistic: True
+    restore_value: True
+  - platform: template
+    name: "Occupancy Mask 1 End Y"
+    id: occupancy_mask_1_end_y
+    max_value: 6000
+    min_value: -1560
+    unit_of_measurement: "mm"
+    step: 10
+    entity_category: config
+    optimistic: True
+    restore_value: True
 
 sensor:
   - platform: template
@@ -716,19 +777,23 @@ uart:
               p1_y = p1_distance * sin((p1_angle - installation_angle)/RADIANS_TO_DEGREES);
             }
             if ((p1_x >= zone1_begin_x_value && p1_x <= zone1_end_x_value) &&
-                (p1_y >= zone1_begin_y_value && p1_y <= zone1_end_y_value)) {
+                (p1_y >= zone1_begin_y_value && p1_y <= zone1_end_y_value) &&
+                not id(target1_masked).state) {
               zone1_count++;
             }
             if ((p1_x >= zone2_begin_x_value && p1_x <= zone2_end_x_value) &&
-                (p1_y >= zone2_begin_y_value && p1_y <= zone2_end_y_value)) {
+                (p1_y >= zone2_begin_y_value && p1_y <= zone2_end_y_value) &&
+                not id(target1_masked).state) {
               zone2_count++;
             }
             if ((p1_x >= zone3_begin_x_value && p1_x <= zone3_end_x_value) &&
-                (p1_y >= zone3_begin_y_value && p1_y <= zone3_end_y_value)) {
+                (p1_y >= zone3_begin_y_value && p1_y <= zone3_end_y_value) &&
+                not id(target1_masked).state) {
               zone3_count++;
             }
             if ((p1_x >= zone4_begin_x_value && p1_x <= zone4_end_x_value) &&
-                (p1_y >= zone4_begin_y_value && p1_y <= zone4_end_y_value)) {
+                (p1_y >= zone4_begin_y_value && p1_y <= zone4_end_y_value) &&
+                not id(target1_masked).state) {
               zone4_count++;
             }
 
@@ -785,19 +850,23 @@ uart:
               p2_y = p2_distance * sin((p2_angle - installation_angle)/RADIANS_TO_DEGREES);
             }
             if ((p2_x >= zone1_begin_x_value && p2_x <= zone1_end_x_value) &&
-                (p2_y >= zone1_begin_y_value && p2_y <= zone1_end_y_value)) {
+                (p2_y >= zone1_begin_y_value && p2_y <= zone1_end_y_value) &&
+                not id(target2_masked).state) {
               zone1_count++;
             }
             if ((p2_x >= zone2_begin_x_value && p2_x <= zone2_end_x_value) &&
-                (p2_y >= zone2_begin_y_value && p2_y <= zone2_end_y_value)) {
+                (p2_y >= zone2_begin_y_value && p2_y <= zone2_end_y_value) &&
+                not id(target2_masked).state) {
               zone2_count++;
             }
             if ((p2_x >= zone3_begin_x_value && p2_x <= zone3_end_x_value) &&
-                (p2_y >= zone3_begin_y_value && p2_y <= zone3_end_y_value)) {
+                (p2_y >= zone3_begin_y_value && p2_y <= zone3_end_y_value) &&
+                not id(target2_masked).state) {
               zone3_count++;
             }
             if ((p2_x >= zone4_begin_x_value && p2_x <= zone4_end_x_value) &&
-                (p2_y >= zone4_begin_y_value && p2_y <= zone4_end_y_value)) {
+                (p2_y >= zone4_begin_y_value && p2_y <= zone4_end_y_value) &&
+                not id(target2_masked).state) {
               zone4_count++;
             }
 
@@ -854,19 +923,23 @@ uart:
               p3_y = p3_distance * sin((p3_angle - installation_angle)/RADIANS_TO_DEGREES);
             }
             if ((p3_x >= zone1_begin_x_value && p3_x <= zone1_end_x_value) &&
-                (p3_y >= zone1_begin_y_value && p3_y <= zone1_end_y_value)) {
+                (p3_y >= zone1_begin_y_value && p3_y <= zone1_end_y_value) &&
+                not id(target3_masked).state) {
               zone1_count++;
             }
             if ((p3_x >= zone2_begin_x_value && p3_x <= zone2_end_x_value) &&
-                (p3_y >= zone2_begin_y_value && p3_y <= zone2_end_y_value)) {
+                (p3_y >= zone2_begin_y_value && p3_y <= zone2_end_y_value) &&
+                not id(target3_masked).state) {
               zone2_count++;
             }
             if ((p3_x >= zone3_begin_x_value && p3_x <= zone3_end_x_value) &&
-                (p3_y >= zone3_begin_y_value && p3_y <= zone3_end_y_value)) {
+                (p3_y >= zone3_begin_y_value && p3_y <= zone3_end_y_value) &&
+                not id(target3_masked).state) {
               zone3_count++;
             }
             if ((p3_x >= zone4_begin_x_value && p3_x <= zone4_end_x_value) &&
-                (p3_y >= zone4_begin_y_value && p3_y <= zone4_end_y_value)) {
+                (p3_y >= zone4_begin_y_value && p3_y <= zone4_end_y_value) &&
+                not id(target3_masked).state) {
               zone4_count++;
             }
 

--- a/epl-map.yml
+++ b/epl-map.yml
@@ -228,6 +228,47 @@ entities:
         $ex { var zone4_begin_y = hass.states[vars.number_name_prefix + "zone_4_begin_y"];
         return zone4_begin_y ? zone4_begin_y.state : -9999; }
   - entity: ''
+    name: OccupancyMask1
+    mode: lines
+    fill: toself
+    fillcolor: RGBA(20,20,20,0.06)
+    line:
+      color: RGBA(20,20,20,0.2)
+      shape: line
+      width: 2
+    x:
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_x"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_x"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_end_x"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_end_x"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_x"].state
+    "y":
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_y"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_end_y"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_end_y"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_y"].state
+      - >-
+        $ex hass.states[vars.number_name_prefix +
+        "occupancy_mask_1_begin_y"].state
+  - entity: ''
     name: Coverage
     mode: lines
     fill: tonexty


### PR DESCRIPTION
This PR makes it possible to add an occupancy mask. Any targets inside an area masked by the mask are not counted for the zone count. I needed this because my pendant light moves a little bit in the wind when my window is open, continuously triggering my automations.

It is based on the code by Daniel Leong [here](https://community.home-assistant.io/t/everything-presence-lite-ignore-targets-within-a-zone/763380)

EDIT: This implementation does not work when the installation angle != 0