### PR TITLE
Fix incorrect update and dashboard URLs

### DIFF
--- a/common/seeed-mmwave-lite-base.yaml
+++ b/common/seeed-mmwave-lite-base.yaml
@@ -67,7 +67,7 @@ sensor:
 
 switch:
   - platform: seeed_mr24hpc1
-    underly_open_function:
+    underlying_open_function:
       name: "Advanced mode"
       id: "advanced_mode"
 

--- a/everything-presence-lite-ha-co2.yaml
+++ b/everything-presence-lite-ha-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-ld2410-co2.yaml
+++ b/everything-presence-lite-ha-ld2410-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-ld2410-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-mr24hpc1-co2.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-no-ble-co2.yaml
@@ -9,11 +9,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-sen0395-co2.yaml
+++ b/everything-presence-lite-ha-sen0395-co2.yaml
@@ -13,11 +13,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-sen0395-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble-co2.yaml
@@ -13,11 +13,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-sen0609-co2.yaml
+++ b/everything-presence-lite-ha-sen0609-co2.yaml
@@ -13,11 +13,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-co2.yaml@main
   import_full_config: false # or true
 
 packages:

--- a/everything-presence-lite-ha-sen0609-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-sen0609-no-ble-co2.yaml
@@ -13,11 +13,11 @@ update:
   - platform: http_request
     id: update_http_request
     name: Everything Presence Lite Firmware
-    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-manifest.json
+    source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-co2-manifest.json
     disabled_by_default: true
 
 dashboard_import:
-  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble.yaml@main
+  package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-co2.yaml@main
   import_full_config: false # or true
 
 packages:


### PR DESCRIPTION
Fixes a bug where aafter flashing a CO2 firmware, importing or updating from the ESPHome add-on would cause it to revert to a non-CO2 firmware