### PR TITLE
Implement BLE beacon support for room_mqtt

### DIFF
--- a/common/bluetooth-base.yaml
+++ b/common/bluetooth-base.yaml
@@ -1,9 +1,74 @@
 esp32_ble_tracker:
   scan_parameters:
     active: true
+  on_ble_advertise:
+    - then:
+        - lambda: |-
+            if (x.get_ibeacon().has_value()) {
+                std::string uuid;
+                esp_bt_uuid_t raw_uuid = x.get_ibeacon().value().get_uuid().get_uuid();
+                char sbuf[64];
+                char *bpos = sbuf;
+                switch (raw_uuid.len) {
+                    case ESP_UUID_LEN_128:
+                        for (int8_t i = 0; i <= 15; i++) {
+                            sprintf(bpos, "%02x", raw_uuid.uuid.uuid128[i]);
+                            bpos += 2;
+                            if (i == 6 || i == 8 || i == 10 || i == 12)
+                                  sprintf(bpos++, "-");
+                        }
+                        sbuf[47] = '\0';
+                        uuid.assign(sbuf);
+                        break;
+                    default:
+                        uuid = x.get_ibeacon().value().get_uuid().to_string();
+                        std::transform(uuid.begin(), uuid.end(), uuid.begin(), [](unsigned char c){ return std::tolower(c); });
+                        break;
+                }
+                char mbuf[32] = {0};
+                int major = x.get_ibeacon().value().get_major();
+                sprintf(mbuf, "-%hu-%hu", x.get_ibeacon().value().get_major(), x.get_ibeacon().value().get_minor());                
+                uuid.append(mbuf);
+                int8_t tx_power = x.get_ibeacon().value().get_signal_power();
+                if (tx_power >= 100) {
+                  tx_power = -69;
+                }
+                float dist = pow(10, (float)(tx_power - x.get_rssi()) / (10 * 2));
+                if (dist < 50 && major == 100) {
+                    ESP_LOGD("ble_adv", "Sending MQTT room update for '%s' (%s): %.03fm (%d rssi, %d sigpow)",
+                             x.get_name().c_str(), uuid.c_str(), dist, x.get_rssi(), tx_power);
+                    id(mqtt_client).publish_json(id(room_topic), [=](JsonObject root) {
+                        root["id"] = uuid;
+                        root["name"] = x.get_name();
+                        root["distance"] = dist;
+                        root["rssi"] = x.get_rssi();
+                        root["tx_power"] = tx_power;
+                    });
+                } else {
+                    ESP_LOGD("ble_adv", "Skipping MQTT room update for '%s' (%s): %.03fm (%d rssi, %d sigpow)",
+                             x.get_name().c_str(), uuid.c_str(), dist, x.get_rssi(), tx_power);
+                }
+            }    
 
 bluetooth_proxy:
   active: true
 
 esp32_improv:
   authorizer: none
+
+mqtt:
+  broker: mqtt.juhonkoti.net
+  discovery: false # Only if you use the HA API usually
+  id: mqtt_client
+  topic_prefix: 'room_presence/radar/${room_name}'
+  log_topic: 
+
+# Define the room for this ESP32 node
+substitutions:
+  room_name: olohuone
+
+# Push the room name into a global
+globals:
+  - id: room_topic
+    type: std::string
+    initial_value: '"room_presence/ble/${room_name}"'  

--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -185,6 +185,7 @@ number:
     restore_value: True
     unit_of_measurement: "s"
     initial_value: 15
+    state_topic: null
   - platform: template
     name: "Max Distance"
     id: distance
@@ -195,6 +196,7 @@ number:
     optimistic: True
     restore_value: True
     initial_value: 600
+    state_topic: null
   - platform: template
     name: "Installation Angle"
     id: installation_angle_ui
@@ -208,7 +210,7 @@ number:
     initial_value: 0
     icon: "mdi:angle-acute"
     entity_category: config
-
+    state_topic: null
   - platform: template
     name: "Zone 1 Begin X"
     id: zone1_begin_x
@@ -219,6 +221,7 @@ number:
     optimistic: True
     restore_value: True
     initial_value: -4000
+    state_topic: null
   - platform: template
     name: "Zone 1 End X"
     id: zone1_end_x
@@ -229,6 +232,7 @@ number:
     optimistic: True
     restore_value: True
     initial_value: 4000
+    state_topic: null
   - platform: template
     name: "Zone 1 Begin Y"
     id: zone1_begin_y
@@ -239,6 +243,7 @@ number:
     optimistic: True
     restore_value: True
     initial_value: 0
+    state_topic: null
   - platform: template
     name: "Zone 1 End Y"
     id: zone1_end_y
@@ -249,6 +254,7 @@ number:
     optimistic: True
     restore_value: True
     initial_value: 6000
+    state_topic: null
   - platform: template
     name: "Zone 1 Occupancy Off Delay"
     id: zone_1_off_delay
@@ -259,7 +265,7 @@ number:
     restore_value: True
     unit_of_measurement: "s"
     initial_value: 15
-
+    state_topic: null
   - platform: template
     name: "Zone 2 Begin X"
     id: zone2_begin_x
@@ -270,6 +276,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null
   - platform: template
     name: "Zone 2 End X"
     id: zone2_end_x
@@ -280,6 +287,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null
   - platform: template
     name: "Zone 2 Begin Y"
     id: zone2_begin_y
@@ -290,6 +298,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null
   - platform: template
     name: "Zone 2 End Y"
     id: zone2_end_y
@@ -300,6 +309,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null
   - platform: template
     name: "Zone 2 Occupancy Off Delay"
     id: zone_2_off_delay
@@ -311,7 +321,7 @@ number:
     unit_of_measurement: "s"
     initial_value: 15
     disabled_by_default: true
-
+    state_topic: null
   - platform: template
     name: "Zone 3 Begin X"
     id: zone3_begin_x
@@ -322,6 +332,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null
   - platform: template
     name: "Zone 3 End X"
     id: zone3_end_x
@@ -332,6 +343,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 3 Begin Y"
     id: zone3_begin_y
@@ -342,6 +354,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 3 End Y"
     id: zone3_end_y
@@ -352,6 +365,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 3 Occupancy Off Delay"
     id: zone_3_off_delay
@@ -363,7 +377,7 @@ number:
     unit_of_measurement: "s"
     initial_value: 15
     disabled_by_default: true
-
+    state_topic: null
   - platform: template
     name: "Zone 4 Begin X"
     id: zone4_begin_x
@@ -374,6 +388,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 4 End X"
     id: zone4_end_x
@@ -384,6 +399,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 4 Begin Y"
     id: zone4_begin_y
@@ -394,6 +410,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 4 End Y"
     id: zone4_end_y
@@ -404,6 +421,7 @@ number:
     optimistic: True
     restore_value: True
     disabled_by_default: true
+    state_topic: null    
   - platform: template
     name: "Zone 4 Occupancy Off Delay"
     id: zone_4_off_delay
@@ -415,7 +433,7 @@ number:
     unit_of_measurement: "s"
     initial_value: 15
     disabled_by_default: true
-
+    state_topic: null
   - platform: template
     name: "Occupancy Mask 1 Begin X"
     id: occupancy_mask_1_begin_x
@@ -425,6 +443,7 @@ number:
     step: 10
     optimistic: True
     restore_value: True
+    state_topic: null    
   - platform: template
     name: "Occupancy Mask 1 End X"
     id: occupancy_mask_1_end_x
@@ -434,6 +453,7 @@ number:
     step: 10
     optimistic: True
     restore_value: True
+    state_topic: null    
   - platform: template
     name: "Occupancy Mask 1 Begin Y"
     id: occupancy_mask_1_begin_y
@@ -441,8 +461,9 @@ number:
     min_value: -1560
     unit_of_measurement: "mm"
     step: 10
-    optimistic: True
+    optimistic: True    
     restore_value: True
+    state_topic: null    
   - platform: template
     name: "Occupancy Mask 1 End Y"
     id: occupancy_mask_1_end_y
@@ -452,6 +473,7 @@ number:
     step: 10
     optimistic: True
     restore_value: True
+    state_topic: null    
 
 sensor:
   - platform: template
@@ -461,6 +483,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 1 Y"
     id: target1_y
@@ -468,6 +491,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 1 Speed"
     id: target1_speed
@@ -475,6 +499,7 @@ sensor:
     unit_of_measurement: 'm/s'
     state_class: measurement
     device_class: speed
+    state_topic: null    
   - platform: template
     name: "Target 1 Resolution"
     id: target1_resolution
@@ -482,6 +507,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 2 X"
     id: target2_x
@@ -489,6 +515,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 2 Y"
     id: target2_y
@@ -496,6 +523,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 2 Speed"
     id: target2_speed
@@ -503,6 +531,7 @@ sensor:
     unit_of_measurement: 'm/s'
     state_class: measurement
     device_class: speed
+    state_topic: null    
   - platform: template
     name: "Target 2 Resolution"
     id: target2_resolution
@@ -510,6 +539,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 3 X"
     id: target3_x
@@ -517,6 +547,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 3 Y"
     id: target3_y
@@ -524,6 +555,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 3 Speed"
     id: target3_speed
@@ -531,6 +563,7 @@ sensor:
     unit_of_measurement: 'm/s'
     state_class: measurement
     device_class: speed
+    state_topic: null    
   - platform: template
     name: "Target 3 Resolution"
     id: target3_resolution
@@ -538,24 +571,28 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 1 Angle"
     id: target1_angle
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
+    state_topic: null    
   - platform: template
     name: "Target 2 Angle"
     id: target2_angle
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
+    state_topic: null    
   - platform: template
     name: "Target 3 Angle"
     id: target3_angle
     accuracy_decimals: 0
     unit_of_measurement: '°'
     state_class: measurement
+    state_topic: null    
   - platform: template
     name: "Target 1 Distance"
     id: target1_distance
@@ -563,6 +600,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 2 Distance"
     id: target2_distance
@@ -570,6 +608,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Target 3 Distance"
     id: target3_distance
@@ -577,6 +616,7 @@ sensor:
     unit_of_measurement: 'mm'
     state_class: measurement
     device_class: distance
+    state_topic: null    
   - platform: template
     name: "Zone 1 Target Count"
     id: zone1_target_count
@@ -606,6 +646,7 @@ sensor:
     accuracy_decimals: 0
     disabled_by_default: true
     unit_of_measurement: " "
+    state_topic: null    
 
 
 uart:

--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -3,7 +3,7 @@ substitutions:
   friendly_name: "Everything Presence Lite"
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
-  log_level: DEBUG
+  log_level: INFO
 
 update:
   - platform: http_request
@@ -20,3 +20,4 @@ packages:
   device_base: !include common/everything-presence-lite-base.yaml
   ld2450_base: !include common/ld2450-base.yaml
   bluetooth_base: !include common/bluetooth-base.yaml
+


### PR DESCRIPTION
This patch adds support for sending BLE beacons to MQTT so that they are compatible with room_mqtt integration. This allows room level location tracking for iBeacon BLE devices (such as Home Assistant Android app).

The code is copied from https://community.home-assistant.io/t/esphome-esp32-ble-tracker-and-has-mqtt-room-platform-sensor/277554 and I've tested it with three Lite modules.

room_mqtt expects the topic name to reflect the room name where the sensor is located and currently this is hard coded as I haven't yet figured out how I could make this configurable via Home Assistant. Same for the mqtt settings. Feedback is appreciated.