### PR TITLE
Add diagnostic sensors for Wi-Fi Signal and ESP Temperature

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -73,6 +73,12 @@ sensor:
       - lambda: "return x + id(illuminance_offset_ui).state;"
       - clamp:
           min_value: 0
+  - platform: wifi_signal
+    disabled_by_default: True
+    name: "WiFi Signal"
+  - platform: internal_temperature
+    disabled_by_default: True
+    name: "ESP Temperature"
 
 button:
   - platform: restart


### PR DESCRIPTION
Added diagnostic sensors and set to disabled by default:

* Wi-Fi Signal: https://esphome.io/components/sensor/wifi_signal.html
* ESP Temperature: https://esphome.io/components/sensor/internal_temperature.html

These are commonly used in a many ESPHome projects/products and really useful for troubleshooting board heat and Wi-Fi connectivity related issues.