### PR TITLE
Add SDC40 temperature and humidity

### DIFF
--- a/common/modules/co2.yaml
+++ b/common/modules/co2.yaml
@@ -21,6 +21,12 @@ sensor:
     co2:
       name: "CO2"
       id: "co2"
+    temperature:
+      name: "Temperature"
+      id: "temperature"
+    humidity:
+      name: "Humidity"
+      id: "humidity"
     automatic_self_calibration: false
 
 button:


### PR DESCRIPTION
The ESP home component for SDC4X also exposes variables for temperature and humidify. Since the EPL is missing these out of the box this would be a highly appreciated feature.

Thanks for the great product! Have been enjoying mine very much so far.