### PR TITLE
Update troubleshooting.md

### DIFF
--- a/static/troubleshooting.md
+++ b/static/troubleshooting.md
@@ -27,6 +27,29 @@ No, it will only show a detected or not detected status.
 
 **I prefer to 3D print my own case** No worries you can find the files you need here [https://www.printables.com/model/624830-everything-presence-lite-official-case](https://www.printables.com/model/624830-everything-presence-lite-official-case "https://www.printables.com/model/624830-everything-presence-lite-official-case")
 
+**My Home Assistant database has grown significantly in size since installing the EPL. Is there anything I can do to prevent this?**
+The entities below are enabled by default and update very frequently, especially if there is a lot of activity in the vicinity of the sensor:
+
+* target_#_active
+* target_#_angle
+* target_#_distance
+* target_#_resolution
+* target_#_speed
+* target_#_x
+* target_#_y
+
+This will expand the size of your Home Assistant database very quickly. Either of the following strategies can help reduce this impact:
+
+1. Disable the entities. This will mean they cannot be monitored or used in automations. The Zone Configurator will not work unless these entities are enabled.
+2. Exclude the entities from the database recorder by adding the following to your `configuration.yaml` file. This will prevent Home Assistant from storing history and long term statistics data for these entities, but they can still be monitored in realtime and used with automations.
+
+```
+recorder:
+  exclude:
+    entity_globs:
+      - sensor.everything_presence_lite*target*
+```
+
 **My EPL stops updating occupancy after some time, light levels are still reported fine.**
 There was a problem with earlier firmware versions of the LD2450 mmWave sensor used by the EPL which can cause a loss of communication until power-cycling the whole device.
 

--- a/static/troubleshooting.md
+++ b/static/troubleshooting.md
@@ -41,7 +41,7 @@ The entities below are enabled by default and update very frequently, especially
 This will expand the size of your Home Assistant database very quickly. Either of the following strategies can help reduce this impact:
 
 1. Disable the entities. This will mean they cannot be monitored or used in automations. The Zone Configurator will not work unless these entities are enabled.
-2. Exclude the entities from the database recorder by adding the following to your `configuration.yaml` file. This will prevent Home Assistant from storing history and long term statistics data for these entities, but they can still be monitored in realtime and used with automations.
+2. Exclude the entities from the database recorder by adding the following to your `configuration.yaml` file. This will prevent Home Assistant from storing history and long term statistics data for these entities, but the Zone Configurator will work, they can be monitored in realtime and continue to be used with automations.
 
 ```
 recorder:


### PR DESCRIPTION
Add guidance to reduce impact on database size.

Context - I have 6 EPLs and my database grew from 500mb to 4.7GB over a couple of weeks. Excluding the entities referenced in this PR from the recorder has brought my database back down to its original size without any impact on the Zone Configurator as I could keep them enabled.