### PR TITLE
Add factory reset button

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -75,7 +75,31 @@ sensor:
       - clamp:
           min_value: 0
 
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: 0
+      inverted: true
+    id: flash_button
+    internal: True
+    on_multi_click:
+      - timing:
+        - ON for at least 10s
+        then:
+          - repeat: 
+              count: 5
+              then:
+                - light.turn_on: esp32_led
+                - delay: 150ms
+                - light.turn_off: esp32_led
+                - delay: 150ms
+          - light.turn_on: esp32_led
+          - button.press: factory_reset_button
+
 button:
   - platform: restart
     icon: mdi:power-cycle
     name: "ESP Reboot"
+  - platform: factory_reset
+    id: "factory_reset_button"
+    internal: True


### PR DESCRIPTION
Add factory reset button to allow to easily factory reset the device without needing access to a computer to flash again.

Done by holding the "boot" button for 10s, the RED LED will blink 5 times and the reset is complete.