### PR TITLE
Add feature to SEN0609: Trigger Distance

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -5,7 +5,7 @@ esphome:
   name_add_mac_suffix: True
   project: 
     name: EverythingSmartTechnology.Everything Presence Lite
-    version: "1.2.3"
+    version: "1.2.4"
 
 esp32:
   board: esp32dev

--- a/common/sen0609-base.yaml
+++ b/common/sen0609-base.yaml
@@ -115,9 +115,9 @@ number:
     name: mmWave Minimum Distance
     icon: mdi:arrow-left-right
     entity_category: config
-    min_value: 0
+    min_value: 0.6
     max_value: 25
-    initial_value: 0
+    initial_value: 0.6
     optimistic: true
     step: 0.1
     restore_value: true
@@ -137,13 +137,13 @@ number:
     unit_of_measurement: m
     mode: slider
   - platform: template
-    id: mmwave_range_reduced
-    name: mmWave Range Reduced
-    icon: mdi:arrow-left-right
+    name: mmWave Trigger Distance
+    icon: mdi:radar
+    id: mmwave_trigger_distance
     entity_category: config
     min_value: 0
     max_value: 25
-    initial_value: 0.8
+    initial_value: 6
     optimistic: true
     step: 0.1
     restore_value: true
@@ -152,9 +152,9 @@ number:
     set_action:
       - switch.turn_off: mmwave_sensor
       - delay: 1s
-      - uart.write: !lambda
-          std::string ms = "setRangeReduced " + to_string(x);
-          return std::vector<unsigned char>(ms.begin(), ms.end());
+      - uart.write: !lambda |-
+          std::string mss = "setTrigRange " + to_string(x);
+          return std::vector<unsigned char>(mss.begin(), mss.end());
       - delay: 1s
       - uart.write: "saveConfig"
       - delay: 1s


### PR DESCRIPTION
Adds a new feature to the SEN0609 that lets the trigger distance be set independently to the sustain distance

Thanks to [@Kuchiru](https://github.com/Kuchiru) for pointing out the problem with setRangeReduced