### PR TITLE
Change CO2 measurement mode to "low_power_periodic"

### DIFF
--- a/common/modules/co2.yaml
+++ b/common/modules/co2.yaml
@@ -18,6 +18,7 @@ sensor:
   - platform: scd4x
     i2c_id: bus_b
     id: scd40
+    measurement_mode: low_power_periodic    
     co2:
       name: "CO2"
       id: "co2"


### PR DESCRIPTION
Change CO2 measurement mode to `low_power_periodic` instead of `periodic` which is the default mode.

`low_power_periodic` takes a new measurement every 30 seconds, `periodic` takes a new measurement every 5 seconds.

According to [https://esphome.io/components/sensor/scd4x.html](https://esphome.io/components/sensor/scd4x.html) the default update interval of the CO2 sensor in ESPHome is 60 seconds. Since EPL does not specify another interval the default will be used.

Because of this `low_power_periodic` with its 30 seconds interval will be frequent enough and reduces power consumption.