### PR TITLE
Add feature for inverse mounting

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -181,7 +181,7 @@ switch:
     entity_category: config
 
   - platform: template
-    name: "Inverse Mounting"
+    name: "Upside Down Mounting"
     id: inverse_mounting
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
@@ -936,6 +936,10 @@ uart:
 
             float p1_distance = sqrt(p1_x * p1_x + p1_y * p1_y);
             
+            if (id(inverse_mounting).state) {
+              p1_x = -p1_x;
+            }
+            
             if (p1_distance > max_distance) {
               p1_detected = false;
             } else {
@@ -947,9 +951,6 @@ uart:
                 float angle = p1_angle - installation_angle;
                 p1_x = p1_distance * cos(angle);
                 p1_y = p1_distance * sin(angle);
-              }
-              if (id(inverse_mounting).state) {
-                p1_x = -p1_x;
               }
               if ((occupancy_mask_1_begin_x_value <= p1_x && p1_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p1_y && p1_y <= occupancy_mask_1_end_y_value)) {
@@ -1062,6 +1063,10 @@ uart:
 
             float p2_distance = sqrt(p2_x * p2_x + p2_y * p2_y);
             
+            if (id(inverse_mounting).state) {
+              p2_x = -p2_x;
+            }
+            
             if (p2_distance > max_distance) {
               p2_detected = false;
             } else {
@@ -1073,9 +1078,6 @@ uart:
                 float angle = p2_angle - installation_angle;
                 p2_x = p2_distance * cos(angle);
                 p2_y = p2_distance * sin(angle);
-              }
-              if (id(inverse_mounting).state) {
-                p2_x = -p2_x;
               }
               if ((occupancy_mask_1_begin_x_value <= p2_x && p2_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p2_y && p2_y <= occupancy_mask_1_end_y_value)) {
@@ -1188,6 +1190,10 @@ uart:
 
             float p3_distance = sqrt(p3_x * p3_x + p3_y * p3_y);
             
+            if (id(inverse_mounting).state) {
+              p3_x = -p3_x;
+            }
+            
             if (p3_distance > max_distance) {
               p3_detected = false;
             } else {
@@ -1199,9 +1205,6 @@ uart:
                 float angle = p3_angle - installation_angle;
                 p3_x = p3_distance * cos(angle);
                 p3_y = p3_distance * sin(angle);
-              }
-              if (id(inverse_mounting).state) {
-                p3_x = -p3_x;
               }
               if ((occupancy_mask_1_begin_x_value <= p3_x && p3_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p3_y && p3_y <= occupancy_mask_1_end_y_value)) {

--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -180,6 +180,14 @@ switch:
     optimistic: True
     entity_category: config
 
+  - platform: template
+    name: "Inverse Mounting"
+    id: inverse_mounting
+    restore_mode: RESTORE_DEFAULT_OFF
+    optimistic: True
+    entity_category: config
+    icon: "mdi:rotate-180"
+
 binary_sensor:
   - platform: template
     name: "Occupancy"
@@ -940,6 +948,9 @@ uart:
                 p1_x = p1_distance * cos(angle);
                 p1_y = p1_distance * sin(angle);
               }
+              if (id(inverse_mounting).state) {
+                p1_x = -p1_x;
+              }
               if ((occupancy_mask_1_begin_x_value <= p1_x && p1_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p1_y && p1_y <= occupancy_mask_1_end_y_value)) {
                 occupancy_mask_1_count++;
@@ -1063,6 +1074,9 @@ uart:
                 p2_x = p2_distance * cos(angle);
                 p2_y = p2_distance * sin(angle);
               }
+              if (id(inverse_mounting).state) {
+                p2_x = -p2_x;
+              }
               if ((occupancy_mask_1_begin_x_value <= p2_x && p2_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p2_y && p2_y <= occupancy_mask_1_end_y_value)) {
                 occupancy_mask_1_count++;
@@ -1185,6 +1199,9 @@ uart:
                 float angle = p3_angle - installation_angle;
                 p3_x = p3_distance * cos(angle);
                 p3_y = p3_distance * sin(angle);
+              }
+              if (id(inverse_mounting).state) {
+                p3_x = -p3_x;
               }
               if ((occupancy_mask_1_begin_x_value <= p3_x && p3_x <= occupancy_mask_1_end_x_value) &&
                   (occupancy_mask_1_begin_y_value <= p3_y && p3_y <= occupancy_mask_1_end_y_value)) {


### PR DESCRIPTION
Adds a new toggle switch for when the Lite is mounted upside down so that tracking information is reflected properly in the Zone Configurator

Fixes https://github.com/EverythingSmartHome/everything-presence-lite/issues/297
