### PR TITLE
CO2 sensor optimization

### DIFF
--- a/common/modules/co2.yaml
+++ b/common/modules/co2.yaml
@@ -7,6 +7,11 @@ api:
         - scd4x.perform_forced_calibration:
             value: !lambda "return co2_ppm;"
             id: scd40
+    - action: set_ambient_pressure
+      variables:
+        pressure_mbar: int
+      then:
+        - lambda: "id(scd40)->set_ambient_pressure_compensation(pressure_mbar);"             
 
 i2c:
   - id: bus_b

--- a/common/modules/co2.yaml
+++ b/common/modules/co2.yaml
@@ -27,6 +27,10 @@ sensor:
     co2:
       name: "CO2"
       id: "co2"
+      filters:
+        - or:
+          - delta: 5%
+          - delta: 5      
     automatic_self_calibration: false
 
 button:


### PR DESCRIPTION
1. Add API to set ambient pressure for CO2 sensor from Home Assistant.
2. Synchronize CO2 value reporting filter with illuminance value reporting filter.