### PR TITLE
Fix "Duplicate binary_sensor entity with name 'Occupancy' found" comp…

### DIFF
--- a/common/ld2410-base.yaml
+++ b/common/ld2410-base.yaml
@@ -23,7 +23,7 @@ binary_sensor:
       name: Still Target
   - platform: gpio
     pin: 18
-    name: Occupancy
+    name: Occupancy GPIO
     device_class: Occupancy
 
 sensor:


### PR DESCRIPTION
This should fix #349 

There is a duplicate entity name "Occupancy" in these lines: 
```
binary_sensor:
  - platform: ld2410
    has_target:
      name: Occupancy
    has_moving_target:
      name: Moving Target
    has_still_target:
      name: Still Target
  - platform: gpio
    pin: 18
    name: Occupancy
    device_class: Occupancy
    ```

I chose to rename the latter to "Occupancy GPIO" and the project compiles again. 