### PR TITLE
update environment variable names for Docker setup

### DIFF
--- a/static/Home Assistant/creating-zones.md
+++ b/static/Home Assistant/creating-zones.md
@@ -38,7 +38,7 @@ Use docker run or docker compose similar to following examples, dont forget to a
 
 *docker run basic example:*
 ```
-docker run -d -e HA_URL=http://HA_URL:8123 -e HA_TOKEN=LONG_LIVE_TOKEN -p 8099:8099 --name everything-presence-mmwave-configurator everythingsmarthome/everything-presence-mmwave-configurator:latest 
+docker run -d -e HA_BASE_URL=http://HA_URL:8123 -e HA_LONG_LIVED_TOKEN=LONG_LIVED_TOKEN -p 8099:8099 --name everything-presence-mmwave-configurator everythingsmarthome/everything-presence-mmwave-configurator:latest 
 ```
 
 *docker compose basic example:*
@@ -50,8 +50,8 @@ services:
     image: everythingsmarthome/everything-presence-mmwave-configurator:latest
     container_name: everything-presence-mmwave-configurator
     environment:
-      - HA_URL=http://10.0.1.11:8123
-      - HA_TOKEN=123-generate-token-at-url:8123/profile/security-456
+      - HA_BASE_URL=http://10.0.1.11:8123
+      - HA_LONG_LIVED_TOKEN=123-generate-token-at-url:8123/profile/security-456
 ```
 
 ### Using the Add-on


### PR DESCRIPTION
When trying to run a docker container by copying and pasting the command from the docs, we get this error

```
Home Assistant credentials are not configured. Provide SUPERVISOR_TOKEN (add-on) or HA_BASE_URL and HA_LONG_LIVED_TOKEN (standalone).
```

This happens because the docs use different environment variable names than the server is expecting. This PR updates the environment variables to match what the server expects.