### PR TITLE
Modified stale target timeout to match documentation (clean PR)

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -748,12 +748,12 @@ number:
     name: "Stale Target Reset Timeout"
     id: aggressive_timeout
     min_value: 1
-    max_value: 60
+    max_value: 600
     step: 1
     unit_of_measurement: "s"
     optimistic: true
     restore_value: true
-    initial_value: 3
+    initial_value: 30
     entity_category: config
 
 sensor:


### PR DESCRIPTION
I mentioned the issue here: https://github.com/EverythingSmartHome/everything-presence-lite/issues/398

It's a cleaner version of this closed PR: https://github.com/EverythingSmartHome/everything-presence-lite/pull/399