### PR TITLE
Change category from diagnostic to config for BLE proxy and CO₂ switches

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -194,7 +194,7 @@ select:
     id: firmware_ble
     name: Bluetooth Proxy
     icon: "mdi:bluetooth"
-    entity_category: diagnostic
+    entity_category: config
     optimistic: true
     restore_value: true
     options:
@@ -206,7 +206,7 @@ select:
     id: firmware_co2
     name: CO2 Sensor
     icon: "mdi:molecule-co2"
-    entity_category: diagnostic
+    entity_category: config
     optimistic: true
     restore_value: true
     options:


### PR DESCRIPTION
They're not diagnostic entities but change the _configuration_ of the device