### PR TITLE
Fix status LED blinking indefinitely (fixes #415)

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -67,18 +67,17 @@ ota:
 http_request:
 
 wifi:
+
+interval:
   # Workaround: ESPHome 2026.4.1+ correctly persists component error flags (PR #15658),
   # but http_request.update never clears its error after a failed manifest fetch,
   # leaving the status LED blinking indefinitely.
-  on_connect:
-    - repeat:
-        count: 12
-        then:
-          - delay: 5s
-          - lambda: |-
-              if (id(update_http_request).status_has_error()) {
-                id(update_http_request).status_clear_error();
-              }
+  - interval: 1min
+    then:
+      - lambda: |-
+          if (id(update_http_request).status_has_error()) {
+            id(update_http_request).status_clear_error();
+          }
 
 improv_serial:
 


### PR DESCRIPTION
Just thought this might be a better solution for the blinking red light. Feel free to close or edit if you don't agree of course.

Replaced the on_connect loop with a global 1-minute interval to continuously clear the http_request.update error flag. This prevents the status LED from flashing indefinitely when an update check fails outside of the initial boot window.