### PR TITLE
Fix checking of updates when BLE is enabled

### DIFF
--- a/common/bluetooth-base.yaml
+++ b/common/bluetooth-base.yaml
@@ -7,3 +7,56 @@ bluetooth_proxy:
 
 esp32_improv:
   authorizer: none
+
+# BLE is delayed on boot so
+# the update check has enough memory, then enabled once the check completes.
+esp32_ble:
+  enable_on_boot: false
+
+esphome:
+  on_boot:
+    priority: -100
+    then:
+      - if:
+          condition:
+            lambda: 'return !wifi::global_wifi_component->has_sta();'
+          then:
+            - logger.log: "No WiFi credentials configured, enabling BLE for Improv setup"
+            - ble.enable
+
+wifi:
+  on_connect:
+    - delay: 15s
+    - ble.disable
+    - delay: 5s
+    - component.update: update_http_request
+    - delay: 10s
+    - lambda: |-
+        if (id(update_http_request).status_has_error()) {
+          id(update_http_request).status_clear_error();
+        }
+    - ble.enable
+
+interval:
+  # Clear stuck error flags that fail because BLE is running.
+  - interval: 30s
+    then:
+      - lambda: |-
+          if (id(update_http_request).status_has_error()) {
+            id(update_http_request).status_clear_error();
+          }
+  - interval: 6h
+    then:
+      - if:
+          condition:
+            wifi.connected:
+          then:
+            - ble.disable
+            - delay: 5s
+            - component.update: update_http_request
+            - delay: 10s
+            - lambda: |-
+                if (id(update_http_request).status_has_error()) {
+                  id(update_http_request).status_clear_error();
+                }
+            - ble.enable

--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -3,7 +3,7 @@ esphome:
   comment: Everything Presence Lite
   friendly_name: ${friendly_name}
   name_add_mac_suffix: True
-  project: 
+  project:
     name: EverythingSmartTechnology.Everything Presence Lite
     version: "1.4.3"
   on_boot:
@@ -26,6 +26,8 @@ esp32:
   board: esp32dev
   framework:
     type: esp-idf
+    advanced:
+      sram1_as_iram: true
 
 # Enable logging
 logger:
@@ -40,12 +42,25 @@ api:
       then:
         - lambda: |-
             ESP_LOGI("fw", "Setting update manifest URL: %s", url.c_str());
+            #ifdef USE_ESP32_BLE
+            if (esp32_ble::global_ble && esp32_ble::global_ble->is_active()) {
+              ESP_LOGI("fw", "Disabling BLE for firmware update");
+              esp32_ble::global_ble->disable();
+            }
+            #endif
             id(update_http_request).set_source_url(url);
+        - delay: 5s
         - component.update: update_http_request
         - delay: 1s
         - update.perform:
             id: update_http_request
             force_update: true
+        - lambda: |-
+            #ifdef USE_ESP32_BLE
+            if (esp32_ble::global_ble) {
+              esp32_ble::global_ble->enable();
+            }
+            #endif
     - action: get_build_flags
       then:
         - api.respond:
@@ -67,18 +82,6 @@ ota:
 http_request:
 
 wifi:
-  # Workaround: ESPHome 2026.4.1+ correctly persists component error flags (PR #15658),
-  # but http_request.update never clears its error after a failed manifest fetch,
-  # leaving the status LED blinking indefinitely.
-  on_connect:
-    - repeat:
-        count: 12
-        then:
-          - delay: 5s
-          - lambda: |-
-              if (id(update_http_request).status_has_error()) {
-                id(update_http_request).status_clear_error();
-              }
 
 improv_serial:
 
@@ -168,6 +171,15 @@ button:
     entity_category: diagnostic
     on_press:
       - logger.log: "Applying firmware update based on selected configuration"
+      # Disable BLE if running
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble && esp32_ble::global_ble->is_active()) {
+            ESP_LOGI("firmware", "Disabling BLE for firmware update");
+            esp32_ble::global_ble->disable();
+          }
+          #endif
+      - delay: 5s
       - lambda: |-
           std::string base_url = "https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha";
           std::string variant = "${device_config.sensor_variant}";
@@ -197,6 +209,14 @@ button:
       - update.perform:
           id: update_http_request
           force_update: true
+      # Re-enable BLE if it was available
+      - lambda: |-
+          #ifdef USE_ESP32_BLE
+          if (esp32_ble::global_ble) {
+            ESP_LOGI("firmware", "Re-enabling BLE after firmware update");
+            esp32_ble::global_ble->enable();
+          }
+          #endif
   - platform: factory_reset
     id: "factory_reset_button"
     internal: True

--- a/everything-presence-lite-ha-co2.yaml
+++ b/everything-presence-lite-ha-co2.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-co2-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-co2.yaml@main

--- a/everything-presence-lite-ha-ld2410-co2.yaml
+++ b/everything-presence-lite-ha-ld2410-co2.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-co2-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-co2.yaml@main

--- a/everything-presence-lite-ha-ld2410.yaml
+++ b/everything-presence-lite-ha-ld2410.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1-co2.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-co2.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-co2-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-co2.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1.yaml
+++ b/everything-presence-lite-ha-mr24hpc1.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1.yaml@main

--- a/everything-presence-lite-ha-sen0395-co2.yaml
+++ b/everything-presence-lite-ha-sen0395-co2.yaml
@@ -25,6 +25,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-co2-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-co2.yaml@main

--- a/everything-presence-lite-ha-sen0395.yaml
+++ b/everything-presence-lite-ha-sen0395.yaml
@@ -25,6 +25,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395.yaml@main

--- a/everything-presence-lite-ha-sen0609-co2.yaml
+++ b/everything-presence-lite-ha-sen0609-co2.yaml
@@ -25,6 +25,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-co2-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-co2.yaml@main

--- a/everything-presence-lite-ha-sen0609.yaml
+++ b/everything-presence-lite-ha-sen0609.yaml
@@ -25,6 +25,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609.yaml@main

--- a/everything-presence-lite-ha.yaml
+++ b/everything-presence-lite-ha.yaml
@@ -21,6 +21,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-manifest.json
     disabled_by_default: true
+    update_interval: never
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha.yaml@main


### PR DESCRIPTION
Fix an issue where checking for updates fails (thus causing a flashing LED constantly) when BLE is enabled. This PR disables BLE while the check for updates occurs then re-enables it again after