### PR TITLE
Fix Bluetooth Proxy scanning after update checks

### DIFF
--- a/common/bluetooth-base.yaml
+++ b/common/bluetooth-base.yaml
@@ -27,8 +27,14 @@ esphome:
 wifi:
   on_connect:
     - delay: 15s
-    - ble.disable
-    - delay: 5s
+    - if:
+        condition:
+          ble.enabled:
+        then:
+          - esp32_ble_tracker.stop_scan:
+          - delay: 5s
+          - ble.disable
+          - delay: 5s
     - component.update: update_http_request
     - delay: 10s
     - lambda: |-
@@ -36,6 +42,9 @@ wifi:
           id(update_http_request).status_clear_error();
         }
     - ble.enable
+    - delay: 5s
+    - esp32_ble_tracker.start_scan:
+        continuous: true
 
 interval:
   # Clear stuck error flags that fail because BLE is running.
@@ -51,8 +60,14 @@ interval:
           condition:
             wifi.connected:
           then:
-            - ble.disable
-            - delay: 5s
+            - if:
+                condition:
+                  ble.enabled:
+                then:
+                  - esp32_ble_tracker.stop_scan:
+                  - delay: 5s
+                  - ble.disable
+                  - delay: 5s
             - component.update: update_http_request
             - delay: 10s
             - lambda: |-
@@ -60,3 +75,6 @@ interval:
                   id(update_http_request).status_clear_error();
                 }
             - ble.enable
+            - delay: 5s
+            - esp32_ble_tracker.start_scan:
+                continuous: true


### PR DESCRIPTION
Fix an issue where Bluetooth Proxy can stop scanning after firmware update checks run with BLE enabled.

This stops the BLE scan before disabling BLE for the update check, then re-enables BLE and restarts continuous scanning afterwards.

Fixes #425