### PR TITLE
Fix deprecated select state usage

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -192,11 +192,11 @@ button:
             base_url += variant;
           }
 
-          if (id(firmware_ble).state == "Disabled") {
+          if (id(firmware_ble).current_option() == "Disabled") {
             base_url += "-no-ble";
           }
 
-          if (id(firmware_co2).state == "Enabled") {
+          if (id(firmware_co2).current_option() == "Enabled") {
             base_url += "-co2";
           }
 


### PR DESCRIPTION
Fix the two deprecated `Select::state` accesses in `common/everything-presence-lite-base.yaml` by switching them to `current_option()`.

This removes the ESPHome deprecation warnings reported during compile and keeps the firmware compatible with the planned removal of `.state` on select entities.

Fixes #387