### PR TITLE
Fix deprecated select state usage in sen0609 lambdas

### DIFF
--- a/common/sen0609-base.yaml
+++ b/common/sen0609-base.yaml
@@ -100,11 +100,11 @@ uart:
 
               // Get throttle interval from user setting
               uint32_t throttle_interval = 400; // Default 0.4s
-              if (id(mmwave_update_rate).state == "0.3s") {
+              if (id(mmwave_update_rate).current_option() == "0.3s") {
                 throttle_interval = 300;
-              } else if (id(mmwave_update_rate).state == "0.4s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.4s") {
                 throttle_interval = 400;
-              } else if (id(mmwave_update_rate).state == "0.5s") {
+              } else if (id(mmwave_update_rate).current_option() == "0.5s") {
                 throttle_interval = 500;
               }
 
@@ -129,7 +129,7 @@ uart:
                 }
 
                 // Update mmWave binary sensor based on target count when in distance mode
-                if (id(mmwave_mode).state == "Distance and Speed") {
+                if (id(mmwave_mode).current_option() == "Distance and Speed") {
                   id(mmwave).publish_state(target_count > 0);
                 }
 
@@ -361,7 +361,7 @@ switch:
     turn_on_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -373,7 +373,7 @@ switch:
     turn_off_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -426,7 +426,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -454,7 +454,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -482,7 +482,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -534,7 +534,7 @@ number:
     set_action:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Distance and Speed";'
+            lambda: 'return id(mmwave_mode).current_option() == "Distance and Speed";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s
@@ -571,7 +571,7 @@ button:
     on_press:
       - if:
           condition:
-            lambda: 'return id(mmwave_mode).state == "Presence Detection";'
+            lambda: 'return id(mmwave_mode).current_option() == "Presence Detection";'
           then:
             - switch.turn_off: mmwave_sensor
             - delay: 1s


### PR DESCRIPTION
Follow-up to #431, which fixed the two `Select::state` calls in `common/everything-presence-lite-base.yaml` (the lines #387 actually called out). This sweeps the remaining 11 deprecated `.state` calls in `common/sen0609-base.yaml` on the `mmwave_mode` and `mmwave_update_rate` selects.

Anyone building the sen0609 variant of EPL still hits the deprecation warnings today, and all of these break when `.state` is removed in ESPHome 2026.7.0. The reporter on #387 didn't see them because they were compiling for LD2450, which doesn't include `sen0609-base.yaml`.

Mirrors the EP1 sweep in EverythingSmartHome/everything-presence-one#322.