### PR TITLE
Redirect legacy docs to Outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ The Everything Presence Lite is a presence sensor for the smart home featuring m
 
 If you'd like to buy the Everything Presence Lite, that is located [here](https://shop.everythingsmart.io/products/everything-presence-lite)
 
-The official user guide for the Everything Presence Lite is located [here](https://everythingsmarthome.github.io/everything-presence-lite/)!
+The official user guide for the Everything Presence Lite is located [here](https://docs.everythingsmart.io/s/products/doc/everything-presence-lite-epl-ZVnBzYzuX2)!
 
 ![Everything Presence One](static/images/everything-presence-lite-front-shot-no-cover.jpg)

--- a/static/_includes/header_custom.html
+++ b/static/_includes/header_custom.html
@@ -1,9 +1,15 @@
-<meta property="og:url" content="https://everythingsmarthome.github.io/everything-presence-one/" />
+{% assign outline_docs_url = "https://docs.everythingsmart.io/s/products/doc/everything-presence-lite-epl-ZVnBzYzuX2" %}
+<link rel="canonical" href="{{ outline_docs_url }}" />
+<meta http-equiv="refresh" content="0; url={{ outline_docs_url }}" />
+<script>
+  window.location.replace("{{ outline_docs_url }}");
+</script>
+<meta property="og:url" content="{{ outline_docs_url }}" />
 <meta property="og:type" content="website" />
-<meta property="og:description" content="User guide and documentation for the Everything Presence One." />
-<meta property="og:image" content="https://everythingsmarthome.github.io/everything-presence-one/images/assembly-complete.jpg" />
+<meta property="og:description" content="Everything Presence Lite documentation." />
+<meta property="og:image" content="https://everythingsmarthome.github.io/everything-presence-lite/images/everything-presence-lite-front-shot-no-cover.jpg" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@everysmarthome" />
-<meta name="twitter:title" content="Everything Presence One - User Guide" />
-<meta name="twitter:description" content="User guide and documentation for the Everything Presence One." />
-<meta name="twitter:image" content="https://everythingsmarthome.github.io/everything-presence-one/images/assembly-complete.jpg" />
+<meta name="twitter:title" content="Everything Presence Lite Documentation" />
+<meta name="twitter:description" content="Everything Presence Lite documentation." />
+<meta name="twitter:image" content="https://everythingsmarthome.github.io/everything-presence-lite/images/everything-presence-lite-front-shot-no-cover.jpg" />


### PR DESCRIPTION
Fixes #185

Redirect the legacy EPL GitHub Pages docs to the current Outline docs landing page, and update the repo README to point at the maintained docs URL.