### PR TITLE
Remove legacy rectangle zones from EPL

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -247,15 +247,6 @@ switch:
     optimistic: true
     entity_category: config
 
-  - platform: template
-    name: "Polygon Zones"
-    id: polygon_zones_enabled
-    restore_mode: RESTORE_DEFAULT_OFF
-    optimistic: true
-    entity_category: config
-    icon: "mdi:vector-polygon"
-    disabled_by_default: false
-
 binary_sensor:
   - platform: template
     name: "Occupancy"
@@ -371,144 +362,6 @@ number:
     entity_category: config
 
   - platform: template
-    name: "Entry Zone 1 Begin X"
-    id: entry_zone_1_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 1 End X"
-    id: entry_zone_1_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 1 Begin Y"
-    id: entry_zone_1_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 1 End Y"
-    id: entry_zone_1_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    entity_category: config
-
-  - platform: template
-    name: "Entry Zone 2 Begin X"
-    id: entry_zone_2_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 2 End X"
-    id: entry_zone_2_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 2 Begin Y"
-    id: entry_zone_2_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Entry Zone 2 End Y"
-    id: entry_zone_2_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: true
-    restore_value: true
-    initial_value: 0
-    disabled_by_default: true
-    entity_category: config
-
-  - platform: template
-    name: "Zone 1 Begin X"
-    id: zone1_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    initial_value: -4000
-    entity_category: config
-  - platform: template
-    name: "Zone 1 End X"
-    id: zone1_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    initial_value: 4000
-    entity_category: config
-  - platform: template
-    name: "Zone 1 Begin Y"
-    id: zone1_begin_y
-    max_value: 6000
-    min_value: -1560 # if epl is rotated 45deg, a target could be detected at negative values: -6000*sin(60deg-45deg) = ~-1552
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    initial_value: 0
-    entity_category: config
-  - platform: template
-    name: "Zone 1 End Y"
-    id: zone1_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    initial_value: 6000
-    entity_category: config
-  - platform: template
     name: "Zone 1 Occupancy Off Delay"
     id: zone_1_off_delay
     max_value: 600
@@ -520,50 +373,6 @@ number:
     initial_value: 15
     entity_category: config
 
-  - platform: template
-    name: "Zone 2 Begin X"
-    id: zone2_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 2 End X"
-    id: zone2_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 2 Begin Y"
-    id: zone2_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 2 End Y"
-    id: zone2_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
   - platform: template
     name: "Zone 2 Occupancy Off Delay"
     id: zone_2_off_delay
@@ -578,50 +387,6 @@ number:
     entity_category: config
 
   - platform: template
-    name: "Zone 3 Begin X"
-    id: zone3_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 3 End X"
-    id: zone3_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 3 Begin Y"
-    id: zone3_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 3 End Y"
-    id: zone3_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
     name: "Zone 3 Occupancy Off Delay"
     id: zone_3_off_delay
     max_value: 600
@@ -635,50 +400,6 @@ number:
     entity_category: config
 
   - platform: template
-    name: "Zone 4 Begin X"
-    id: zone4_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 4 End X"
-    id: zone4_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 4 Begin Y"
-    id: zone4_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Zone 4 End Y"
-    id: zone4_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
     name: "Zone 4 Occupancy Off Delay"
     id: zone_4_off_delay
     max_value: 600
@@ -688,91 +409,6 @@ number:
     restore_value: True
     unit_of_measurement: "s"
     initial_value: 15
-    disabled_by_default: true
-    entity_category: config
-
-  - platform: template
-    name: "Occupancy Mask 1 Begin X"
-    id: occupancy_mask_1_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 1 End X"
-    id: occupancy_mask_1_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 1 Begin Y"
-    id: occupancy_mask_1_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 1 End Y"
-    id: occupancy_mask_1_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 2 Begin X"
-    id: occupancy_mask_2_begin_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 2 End X"
-    id: occupancy_mask_2_end_x
-    max_value: 6000
-    min_value: -6000
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 2 Begin Y"
-    id: occupancy_mask_2_begin_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
-    disabled_by_default: true
-    entity_category: config
-  - platform: template
-    name: "Occupancy Mask 2 End Y"
-    id: occupancy_mask_2_end_y
-    max_value: 6000
-    min_value: -1560
-    unit_of_measurement: "mm"
-    step: 10
-    optimistic: True
-    restore_value: True
     disabled_by_default: true
     entity_category: config
 
@@ -1392,43 +1028,13 @@ uart:
             return inside;
           };
 
-          bool polygon_mode = id(polygon_zones_enabled).state;
-
-          // Extracted for consistency of read values
           int zone1_count = 0;
-          int zone1_begin_x_value = min(id(zone1_begin_x).state, id(zone1_end_x).state);
-          int zone1_end_x_value = max(id(zone1_begin_x).state, id(zone1_end_x).state);
-          int zone1_begin_y_value = min(id(zone1_begin_y).state, id(zone1_end_y).state);
-          int zone1_end_y_value = max(id(zone1_begin_y).state, id(zone1_end_y).state);
-
           int zone2_count = 0;
-          int zone2_begin_x_value = min(id(zone2_begin_x).state, id(zone2_end_x).state);
-          int zone2_end_x_value = max(id(zone2_begin_x).state, id(zone2_end_x).state);
-          int zone2_begin_y_value = min(id(zone2_begin_y).state, id(zone2_end_y).state);
-          int zone2_end_y_value = max(id(zone2_begin_y).state, id(zone2_end_y).state);
-
           int zone3_count = 0;
-          int zone3_begin_x_value = min(id(zone3_begin_x).state, id(zone3_end_x).state);
-          int zone3_end_x_value = max(id(zone3_begin_x).state, id(zone3_end_x).state);
-          int zone3_begin_y_value = min(id(zone3_begin_y).state, id(zone3_end_y).state);
-          int zone3_end_y_value = max(id(zone3_begin_y).state, id(zone3_end_y).state);
-
           int zone4_count = 0;
-          int zone4_begin_x_value = min(id(zone4_begin_x).state, id(zone4_end_x).state);
-          int zone4_end_x_value = max(id(zone4_begin_x).state, id(zone4_end_x).state);
-          int zone4_begin_y_value = min(id(zone4_begin_y).state, id(zone4_end_y).state);
-          int zone4_end_y_value = max(id(zone4_begin_y).state, id(zone4_end_y).state);
 
           int occupancy_mask_1_count = 0;
-          int occupancy_mask_1_begin_x_value = min(id(occupancy_mask_1_begin_x).state, id(occupancy_mask_1_end_x).state);
-          int occupancy_mask_1_end_x_value = max(id(occupancy_mask_1_begin_x).state, id(occupancy_mask_1_end_x).state);
-          int occupancy_mask_1_begin_y_value = min(id(occupancy_mask_1_begin_y).state, id(occupancy_mask_1_end_y).state);
-          int occupancy_mask_1_end_y_value = max(id(occupancy_mask_1_begin_y).state, id(occupancy_mask_1_end_y).state);
           int occupancy_mask_2_count = 0;
-          int occupancy_mask_2_begin_x_value = min(id(occupancy_mask_2_begin_x).state, id(occupancy_mask_2_end_x).state);
-          int occupancy_mask_2_end_x_value = max(id(occupancy_mask_2_begin_x).state, id(occupancy_mask_2_end_x).state);
-          int occupancy_mask_2_begin_y_value = min(id(occupancy_mask_2_begin_y).state, id(occupancy_mask_2_end_y).state);
-          int occupancy_mask_2_end_y_value = max(id(occupancy_mask_2_begin_y).state, id(occupancy_mask_2_end_y).state);
 
           bool p1_detected = *((uint16_t *)(&bytes[10])) != 0;
           bool p2_detected = *((uint16_t *)(&bytes[18])) != 0;
@@ -1462,65 +1068,30 @@ uart:
                 p1_x = p1_distance * cos(angle);
                 p1_y = p1_distance * sin(angle);
               }
-              if (polygon_mode) {
-                if (point_in_poly(p1_x, p1_y, id(poly_exclusion_1_points))) {
-                  occupancy_mask_1_count++;
-                  p1_detected = false;
-                  target_masked = true;
-                } else if (point_in_poly(p1_x, p1_y, id(poly_exclusion_2_points))) {
-                  occupancy_mask_2_count++;
-                  p1_detected = false;
-                  target_masked = true;
-                } else {
-                  if (point_in_poly(p1_x, p1_y, id(poly_zone_1_points))) {
-                    zone1_count++;
-                    id(last_zone_hold) = 1;
-                  }
-                  if (point_in_poly(p1_x, p1_y, id(poly_zone_2_points))) {
-                    zone2_count++;
-                    id(last_zone_hold) = 2;
-                  }
-                  if (point_in_poly(p1_x, p1_y, id(poly_zone_3_points))) {
-                    zone3_count++;
-                    id(last_zone_hold) = 3;
-                  }
-                  if (point_in_poly(p1_x, p1_y, id(poly_zone_4_points))) {
-                    zone4_count++;
-                    id(last_zone_hold) = 4;
-                  }
-                }
+              if (point_in_poly(p1_x, p1_y, id(poly_exclusion_1_points))) {
+                occupancy_mask_1_count++;
+                p1_detected = false;
+                target_masked = true;
+              } else if (point_in_poly(p1_x, p1_y, id(poly_exclusion_2_points))) {
+                occupancy_mask_2_count++;
+                p1_detected = false;
+                target_masked = true;
               } else {
-                if ((occupancy_mask_1_begin_x_value <= p1_x && p1_x <= occupancy_mask_1_end_x_value) &&
-                    (occupancy_mask_1_begin_y_value <= p1_y && p1_y <= occupancy_mask_1_end_y_value)) {
-                  occupancy_mask_1_count++;
-                  p1_detected = false;
-                  target_masked = true;
-                } else if ((occupancy_mask_2_begin_x_value <= p1_x && p1_x <= occupancy_mask_2_end_x_value) &&
-                    (occupancy_mask_2_begin_y_value <= p1_y && p1_y <= occupancy_mask_2_end_y_value)) {
-                  occupancy_mask_2_count++;
-                  p1_detected = false;
-                  target_masked = true;
-                } else {
-                  if ((zone1_begin_x_value <= p1_x && p1_x <= zone1_end_x_value) &&
-                      (zone1_begin_y_value <= p1_y && p1_y <= zone1_end_y_value)) {
-                    zone1_count++;
-                    id(last_zone_hold) = 1;
-                  }
-                  if ((zone2_begin_x_value <= p1_x && p1_x <= zone2_end_x_value) &&
-                      (zone2_begin_y_value <= p1_y && p1_y <= zone2_end_y_value)) {
-                    zone2_count++;
-                    id(last_zone_hold) = 2;
-                  }
-                  if ((zone3_begin_x_value <= p1_x && p1_x <= zone3_end_x_value) &&
-                      (zone3_begin_y_value <= p1_y && p1_y <= zone3_end_y_value)) {
-                    zone3_count++;
-                    id(last_zone_hold) = 3;
-                  }
-                  if ((zone4_begin_x_value <= p1_x && p1_x <= zone4_end_x_value) &&
-                      (zone4_begin_y_value <= p1_y && p1_y <= zone4_end_y_value)) {
-                    zone4_count++;
-                    id(last_zone_hold) = 4;
-                  }
+                if (point_in_poly(p1_x, p1_y, id(poly_zone_1_points))) {
+                  zone1_count++;
+                  id(last_zone_hold) = 1;
+                }
+                if (point_in_poly(p1_x, p1_y, id(poly_zone_2_points))) {
+                  zone2_count++;
+                  id(last_zone_hold) = 2;
+                }
+                if (point_in_poly(p1_x, p1_y, id(poly_zone_3_points))) {
+                  zone3_count++;
+                  id(last_zone_hold) = 3;
+                }
+                if (point_in_poly(p1_x, p1_y, id(poly_zone_4_points))) {
+                  zone4_count++;
+                  id(last_zone_hold) = 4;
                 }
               }
               if (update_entities) {
@@ -1634,54 +1205,19 @@ uart:
                 p2_x = p2_distance * cos(angle);
                 p2_y = p2_distance * sin(angle);
               }
-              if (polygon_mode) {
-                if (point_in_poly(p2_x, p2_y, id(poly_exclusion_1_points))) {
-                  occupancy_mask_1_count++;
-                  p2_detected = false;
-                  target_masked = true;
-                } else if (point_in_poly(p2_x, p2_y, id(poly_exclusion_2_points))) {
-                  occupancy_mask_2_count++;
-                  p2_detected = false;
-                  target_masked = true;
-                } else {
-                  if (point_in_poly(p2_x, p2_y, id(poly_zone_1_points))) { zone1_count++; id(last_zone_hold) = 1; }
-                  if (point_in_poly(p2_x, p2_y, id(poly_zone_2_points))) { zone2_count++; id(last_zone_hold) = 2; }
-                  if (point_in_poly(p2_x, p2_y, id(poly_zone_3_points))) { zone3_count++; id(last_zone_hold) = 3; }
-                  if (point_in_poly(p2_x, p2_y, id(poly_zone_4_points))) { zone4_count++; id(last_zone_hold) = 4; }
-                }
+              if (point_in_poly(p2_x, p2_y, id(poly_exclusion_1_points))) {
+                occupancy_mask_1_count++;
+                p2_detected = false;
+                target_masked = true;
+              } else if (point_in_poly(p2_x, p2_y, id(poly_exclusion_2_points))) {
+                occupancy_mask_2_count++;
+                p2_detected = false;
+                target_masked = true;
               } else {
-                if ((occupancy_mask_1_begin_x_value <= p2_x && p2_x <= occupancy_mask_1_end_x_value) &&
-                    (occupancy_mask_1_begin_y_value <= p2_y && p2_y <= occupancy_mask_1_end_y_value)) {
-                  occupancy_mask_1_count++;
-                  p2_detected = false;
-                  target_masked = true;
-                } else if ((occupancy_mask_2_begin_x_value <= p2_x && p2_x <= occupancy_mask_2_end_x_value) &&
-                    (occupancy_mask_2_begin_y_value <= p2_y && p2_y <= occupancy_mask_2_end_y_value)) {
-                  occupancy_mask_2_count++;
-                  p2_detected = false;
-                  target_masked = true;
-                } else {
-                  if ((zone1_begin_x_value <= p2_x && p2_x <= zone1_end_x_value) &&
-                      (zone1_begin_y_value <= p2_y && p2_y <= zone1_end_y_value)) {
-                    zone1_count++;
-                    id(last_zone_hold) = 1;
-                  }
-                  if ((zone2_begin_x_value <= p2_x && p2_x <= zone2_end_x_value) &&
-                      (zone2_begin_y_value <= p2_y && p2_y <= zone2_end_y_value)) {
-                    zone2_count++;
-                    id(last_zone_hold) = 2;
-                  }
-                  if ((zone3_begin_x_value <= p2_x && p2_x <= zone3_end_x_value) &&
-                      (zone3_begin_y_value <= p2_y && p2_y <= zone3_end_y_value)) {
-                    zone3_count++;
-                    id(last_zone_hold) = 3;
-                  }
-                  if ((zone4_begin_x_value <= p2_x && p2_x <= zone4_end_x_value) &&
-                      (zone4_begin_y_value <= p2_y && p2_y <= zone4_end_y_value)) {
-                    zone4_count++;
-                    id(last_zone_hold) = 4;
-                  }
-                }
+                if (point_in_poly(p2_x, p2_y, id(poly_zone_1_points))) { zone1_count++; id(last_zone_hold) = 1; }
+                if (point_in_poly(p2_x, p2_y, id(poly_zone_2_points))) { zone2_count++; id(last_zone_hold) = 2; }
+                if (point_in_poly(p2_x, p2_y, id(poly_zone_3_points))) { zone3_count++; id(last_zone_hold) = 3; }
+                if (point_in_poly(p2_x, p2_y, id(poly_zone_4_points))) { zone4_count++; id(last_zone_hold) = 4; }
               }
               if (update_entities) {
                 switch (id(extra_entities)) {
@@ -1793,54 +1329,19 @@ uart:
                 p3_x = p3_distance * cos(angle);
                 p3_y = p3_distance * sin(angle);
               }
-              if (polygon_mode) {
-                if (point_in_poly(p3_x, p3_y, id(poly_exclusion_1_points))) {
-                  occupancy_mask_1_count++;
-                  p3_detected = false;
-                  target_masked = true;
-                } else if (point_in_poly(p3_x, p3_y, id(poly_exclusion_2_points))) {
-                  occupancy_mask_2_count++;
-                  p3_detected = false;
-                  target_masked = true;
-                } else {
-                  if (point_in_poly(p3_x, p3_y, id(poly_zone_1_points))) { zone1_count++; id(last_zone_hold) = 1; }
-                  if (point_in_poly(p3_x, p3_y, id(poly_zone_2_points))) { zone2_count++; id(last_zone_hold) = 2; }
-                  if (point_in_poly(p3_x, p3_y, id(poly_zone_3_points))) { zone3_count++; id(last_zone_hold) = 3; }
-                  if (point_in_poly(p3_x, p3_y, id(poly_zone_4_points))) { zone4_count++; id(last_zone_hold) = 4; }
-                }
+              if (point_in_poly(p3_x, p3_y, id(poly_exclusion_1_points))) {
+                occupancy_mask_1_count++;
+                p3_detected = false;
+                target_masked = true;
+              } else if (point_in_poly(p3_x, p3_y, id(poly_exclusion_2_points))) {
+                occupancy_mask_2_count++;
+                p3_detected = false;
+                target_masked = true;
               } else {
-                if ((occupancy_mask_1_begin_x_value <= p3_x && p3_x <= occupancy_mask_1_end_x_value) &&
-                    (occupancy_mask_1_begin_y_value <= p3_y && p3_y <= occupancy_mask_1_end_y_value)) {
-                  occupancy_mask_1_count++;
-                  p3_detected = false;
-                  target_masked = true;
-                } else if ((occupancy_mask_2_begin_x_value <= p3_x && p3_x <= occupancy_mask_2_end_x_value) &&
-                    (occupancy_mask_2_begin_y_value <= p3_y && p3_y <= occupancy_mask_2_end_y_value)) {
-                  occupancy_mask_2_count++;
-                  p3_detected = false;
-                  target_masked = true;
-                } else {
-                  if ((zone1_begin_x_value <= p3_x && p3_x <= zone1_end_x_value) &&
-                      (zone1_begin_y_value <= p3_y && p3_y <= zone1_end_y_value)) {
-                    zone1_count++;
-                    id(last_zone_hold) = 1;
-                  }
-                  if ((zone2_begin_x_value <= p3_x && p3_x <= zone2_end_x_value) &&
-                      (zone2_begin_y_value <= p3_y && p3_y <= zone2_end_y_value)) {
-                    zone2_count++;
-                    id(last_zone_hold) = 2;
-                  }
-                  if ((zone3_begin_x_value <= p3_x && p3_x <= zone3_end_x_value) &&
-                      (zone3_begin_y_value <= p3_y && p3_y <= zone3_end_y_value)) {
-                    zone3_count++;
-                    id(last_zone_hold) = 3;
-                  }
-                  if ((zone4_begin_x_value <= p3_x && p3_x <= zone4_end_x_value) &&
-                      (zone4_begin_y_value <= p3_y && p3_y <= zone4_end_y_value)) {
-                    zone4_count++;
-                    id(last_zone_hold) = 4;
-                  }
-                }
+                if (point_in_poly(p3_x, p3_y, id(poly_zone_1_points))) { zone1_count++; id(last_zone_hold) = 1; }
+                if (point_in_poly(p3_x, p3_y, id(poly_zone_2_points))) { zone2_count++; id(last_zone_hold) = 2; }
+                if (point_in_poly(p3_x, p3_y, id(poly_zone_3_points))) { zone3_count++; id(last_zone_hold) = 3; }
+                if (point_in_poly(p3_x, p3_y, id(poly_zone_4_points))) { zone4_count++; id(last_zone_hold) = 4; }
               }
               if (update_entities) {
                 switch (id(extra_entities)) {
@@ -1956,32 +1457,21 @@ uart:
           static Sample hist[3][BUF_SZ];
           static uint16_t head[3] = {0,0,0};
 
-          int e1_x1 = min((int)id(entry_zone_1_begin_x).state, (int)id(entry_zone_1_end_x).state);
-          int e1_x2 = max((int)id(entry_zone_1_begin_x).state, (int)id(entry_zone_1_end_x).state);
-          int e1_y1 = min((int)id(entry_zone_1_begin_y).state, (int)id(entry_zone_1_end_y).state);
-          int e1_y2 = max((int)id(entry_zone_1_begin_y).state, (int)id(entry_zone_1_end_y).state);
-          int e2_x1 = min((int)id(entry_zone_2_begin_x).state, (int)id(entry_zone_2_end_x).state);
-          int e2_x2 = max((int)id(entry_zone_2_begin_x).state, (int)id(entry_zone_2_end_x).state);
-          int e2_y1 = min((int)id(entry_zone_2_begin_y).state, (int)id(entry_zone_2_end_y).state);
-          int e2_y2 = max((int)id(entry_zone_2_begin_y).state, (int)id(entry_zone_2_end_y).state);
-
           float poly_e1_y_min = 0, poly_e1_y_max = 0, poly_e2_y_min = 0, poly_e2_y_max = 0;
-          if (polygon_mode) {
-            if (id(poly_entry_1_points).size() >= 6) {
-              poly_e1_y_min = poly_e1_y_max = id(poly_entry_1_points)[1];
-              for (size_t vi = 1; vi < id(poly_entry_1_points).size() / 2; vi++) {
-                float y = id(poly_entry_1_points)[vi * 2 + 1];
-                if (y < poly_e1_y_min) poly_e1_y_min = y;
-                if (y > poly_e1_y_max) poly_e1_y_max = y;
-              }
+          if (id(poly_entry_1_points).size() >= 6) {
+            poly_e1_y_min = poly_e1_y_max = id(poly_entry_1_points)[1];
+            for (size_t vi = 1; vi < id(poly_entry_1_points).size() / 2; vi++) {
+              float y = id(poly_entry_1_points)[vi * 2 + 1];
+              if (y < poly_e1_y_min) poly_e1_y_min = y;
+              if (y > poly_e1_y_max) poly_e1_y_max = y;
             }
-            if (id(poly_entry_2_points).size() >= 6) {
-              poly_e2_y_min = poly_e2_y_max = id(poly_entry_2_points)[1];
-              for (size_t vi = 1; vi < id(poly_entry_2_points).size() / 2; vi++) {
-                float y = id(poly_entry_2_points)[vi * 2 + 1];
-                if (y < poly_e2_y_min) poly_e2_y_min = y;
-                if (y > poly_e2_y_max) poly_e2_y_max = y;
-              }
+          }
+          if (id(poly_entry_2_points).size() >= 6) {
+            poly_e2_y_min = poly_e2_y_max = id(poly_entry_2_points)[1];
+            for (size_t vi = 1; vi < id(poly_entry_2_points).size() / 2; vi++) {
+              float y = id(poly_entry_2_points)[vi * 2 + 1];
+              if (y < poly_e2_y_min) poly_e2_y_min = y;
+              if (y > poly_e2_y_max) poly_e2_y_max = y;
             }
           }
 
@@ -2004,8 +1494,8 @@ uart:
               for (int i = 0; i < 3; i++) {
                 if (prev_detected[i] && !detected_now[i]) {
                   float len_e1 = 0.0f, len_e2 = 0.0f;
-                  bool e1_valid = polygon_mode ? (id(poly_entry_1_points).size() >= 6) : !(e1_x1 == e1_x2 && e1_y1 == e1_y2);
-                  bool e2_valid = polygon_mode ? (id(poly_entry_2_points).size() >= 6) : !(e2_x1 == e2_x2 && e2_y1 == e2_y2);
+                  bool e1_valid = id(poly_entry_1_points).size() >= 6;
+                  bool e2_valid = id(poly_entry_2_points).size() >= 6;
                   if (e1_valid) {
                     uint16_t ii = head[i];
                     unsigned int steps = 0;
@@ -2017,7 +1507,7 @@ uart:
                       if (now_ms - b.t > window_ms) break;
                       float mx = 0.5f * (a.x + b.x);
                       float my = 0.5f * (a.y + b.y);
-                      bool in_e1 = polygon_mode ? point_in_poly(mx, my, id(poly_entry_1_points)) : (mx >= e1_x1 && mx <= e1_x2 && my >= e1_y1 && my <= e1_y2);
+                      bool in_e1 = point_in_poly(mx, my, id(poly_entry_1_points));
                       if (in_e1) {
                         float dx = b.x - a.x;
                         float dy = b.y - a.y;
@@ -2037,7 +1527,7 @@ uart:
                       if (now_ms - b2.t > window_ms) break;
                       float mx2 = 0.5f * (a2.x + b2.x);
                       float my2 = 0.5f * (a2.y + b2.y);
-                      bool in_e2 = polygon_mode ? point_in_poly(mx2, my2, id(poly_entry_2_points)) : (mx2 >= e2_x1 && mx2 <= e2_x2 && my2 >= e2_y1 && my2 <= e2_y2);
+                      bool in_e2 = point_in_poly(mx2, my2, id(poly_entry_2_points));
                       if (in_e2) {
                         float dx2 = b2.x - a2.x;
                         float dy2 = b2.y - a2.y;
@@ -2046,8 +1536,8 @@ uart:
                       ii2 = jj2; steps2++;
                     }
                   }
-                  float door1_depth = polygon_mode ? abs(poly_e1_y_max - poly_e1_y_min) : abs(e1_y2 - e1_y1);
-                  float door2_depth = polygon_mode ? abs(poly_e2_y_max - poly_e2_y_min) : abs(e2_y2 - e2_y1);
+                  float door1_depth = abs(poly_e1_y_max - poly_e1_y_min);
+                  float door2_depth = abs(poly_e2_y_max - poly_e2_y_min);
                   bool valid_exit = false;
                   if (door1_depth > 0 && len_e1 >= door1_depth * threshold_scale) valid_exit = true;
                   if (door2_depth > 0 && len_e2 >= door2_depth * threshold_scale) valid_exit = true;


### PR DESCRIPTION
## Summary
- remove the legacy rectangular occupancy, entry, and exclusion zone entities from EPL
- remove the polygon mode toggle and make the occupancy path polygon-only like EP Pro
- keep polygon zones and per-zone occupancy off-delay entities intact

Refs #439