### PR TITLE
Add entry exit diagnostics

### DIFF
--- a/common/ld2450-base.yaml
+++ b/common/ld2450-base.yaml
@@ -3,6 +3,12 @@ esphome:
     priority: -100
     then:
       - button.press: get_mmwave_firmware
+      - text_sensor.template.publish:
+          id: entry_exit_last_decision
+          state: "Idle"
+      - text_sensor.template.publish:
+          id: entry_exit_last_zone
+          state: "None"
       - binary_sensor.template.publish:
           id: zone1_occupancy
           state: false 
@@ -122,6 +128,16 @@ text_sensor:
     name: "mmWave Firmware"
     id: "firmware_version"
     entity_category: diagnostic
+  - platform: template
+    name: "Entry Exit Last Decision"
+    id: entry_exit_last_decision
+    entity_category: diagnostic
+    disabled_by_default: true
+  - platform: template
+    name: "Entry Exit Last Entry Zone"
+    id: entry_exit_last_zone
+    entity_category: diagnostic
+    disabled_by_default: true
 
 button:
   - platform: template
@@ -432,6 +448,22 @@ sensor:
     accuracy_decimals: 0
     update_interval: never
     entity_category: diagnostic
+  - platform: template
+    name: "Entry Exit Last Target X"
+    id: entry_exit_last_target_x
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    update_interval: never
+    entity_category: diagnostic
+    disabled_by_default: true
+  - platform: template
+    name: "Entry Exit Last Target Y"
+    id: entry_exit_last_target_y
+    accuracy_decimals: 0
+    unit_of_measurement: 'mm'
+    update_interval: never
+    entity_category: diagnostic
+    disabled_by_default: true
   - platform: template
     name: "Target 1 X"
     id: target1_x
@@ -1482,7 +1514,12 @@ uart:
 
           bool detected_now[3] = {p1_detected, p2_detected, p3_detected};
           bool any_detected_now = p1_detected || p2_detected || p3_detected;
+          bool had_hold = (assumed_present_until != 0 && now_ms < assumed_present_until);
           if (any_detected_now) {
+            if (had_hold) {
+              id(entry_exit_last_decision).publish_state("Target Reacquired");
+              id(entry_exit_last_zone).publish_state("None");
+            }
             assumed_present_until = 0;
           }
 
@@ -1538,14 +1575,31 @@ uart:
                   }
                   float door1_depth = abs(poly_e1_y_max - poly_e1_y_min);
                   float door2_depth = abs(poly_e2_y_max - poly_e2_y_min);
-                  bool valid_exit = false;
-                  if (door1_depth > 0 && len_e1 >= door1_depth * threshold_scale) valid_exit = true;
-                  if (door2_depth > 0 && len_e2 >= door2_depth * threshold_scale) valid_exit = true;
+                  bool exit_e1 = door1_depth > 0 && len_e1 >= door1_depth * threshold_scale;
+                  bool exit_e2 = door2_depth > 0 && len_e2 >= door2_depth * threshold_scale;
+                  bool valid_exit = exit_e1 || exit_e2;
+                  const char *decision_zone = "None";
+                  if (exit_e1 && exit_e2) {
+                    decision_zone = "Both";
+                  } else if (exit_e1) {
+                    decision_zone = "Entry 1";
+                  } else if (exit_e2) {
+                    decision_zone = "Entry 2";
+                  } else if (e1_valid || e2_valid) {
+                    decision_zone = "Unknown";
+                  }
+                  id(entry_exit_last_target_x).publish_state(id(last_target_x_mm));
+                  id(entry_exit_last_target_y).publish_state(id(last_target_y_mm));
                   if (!valid_exit) {
                     unsigned long hold_ms = (unsigned long) (id(assume_present_timeout_s).state * 1000.0f);
                     if (hold_ms > 0) {
                       assumed_present_until = now_ms + hold_ms;
+                      id(entry_exit_last_decision).publish_state("Hold Started");
+                      id(entry_exit_last_zone).publish_state(decision_zone);
                     }
+                  } else {
+                    id(entry_exit_last_decision).publish_state("Valid Exit");
+                    id(entry_exit_last_zone).publish_state(decision_zone);
                   }
                   break;
                 }
@@ -1570,6 +1624,10 @@ uart:
             id(assumed_present_remaining_s).publish_state(remain);
           } else {
             id(assumed_present_remaining_s).publish_state(0);
+          }
+          if (had_hold && !hold_active && !any_detected_now) {
+            id(entry_exit_last_decision).publish_state("Hold Expired");
+            id(entry_exit_last_zone).publish_state("None");
           }
           bool hold_active2 = (assumed_present_until != 0 && millis() < assumed_present_until);
           bool z1 = zone1_count > 0; if (hold_active2 && id(last_zone_hold) == 1) z1 = true;


### PR DESCRIPTION
Refs #437

## Summary
- add lightweight entry/exit diagnostic entities for EPL assumed presence troubleshooting
- expose the last decision, entry zone, and last target position from the existing hold logic
- update the diagnostics on hold start, valid exit, hold expiry, and target reacquire