### PR TITLE
Suppressed `WARNING GPIO0 is a strapping PIN…`

### DIFF
--- a/common/everything-presence-lite-base.yaml
+++ b/common/everything-presence-lite-base.yaml
@@ -139,6 +139,7 @@ binary_sensor:
     pin:
       number: 0
       inverted: true
+      ignore_strapping_warning: true
     id: flash_button
     internal: True
     filters:


### PR DESCRIPTION
Suppressed `WARNING GPIO0 is a strapping PIN and should only be used for I/O with care.` as it does not cause any issues.