### PR TITLE
Add substitution to allow automatic update checks to be disabled

### DIFF
--- a/common/bluetooth-base.yaml
+++ b/common/bluetooth-base.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  update_checks: true
+
 esp32_ble_tracker:
   scan_parameters:
     active: true
@@ -29,18 +32,22 @@ wifi:
     - delay: 15s
     - if:
         condition:
-          ble.enabled:
+          lambda: 'return ${update_checks | lower};'
         then:
-          - esp32_ble_tracker.stop_scan:
-          - delay: 5s
-          - ble.disable
-          - delay: 5s
-    - component.update: update_http_request
-    - delay: 10s
-    - lambda: |-
-        if (id(update_http_request).status_has_error()) {
-          id(update_http_request).status_clear_error();
-        }
+          - if:
+              condition:
+                ble.enabled:
+              then:
+                - esp32_ble_tracker.stop_scan:
+                - delay: 5s
+                - ble.disable
+                - delay: 5s
+          - component.update: update_http_request
+          - delay: 10s
+          - lambda: |-
+              if (id(update_http_request).status_has_error()) {
+                id(update_http_request).status_clear_error();
+              }
     - ble.enable
     - delay: 5s
     - esp32_ble_tracker.start_scan:
@@ -58,7 +65,9 @@ interval:
     then:
       - if:
           condition:
-            wifi.connected:
+            and:
+              - lambda: 'return ${update_checks | lower};'
+              - wifi.connected:
           then:
             - if:
                 condition:

--- a/everything-presence-lite-ha-ld2410-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble-co2.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-co2-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-co2.yaml@main

--- a/everything-presence-lite-ha-ld2410-no-ble.yaml
+++ b/everything-presence-lite-ha-ld2410-no-ble.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-ld2410-no-ble.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-co2-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-co2.yaml@main

--- a/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
+++ b/everything-presence-lite-ha-mr24hpc1-no-ble.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-mr24hpc1-no-ble.yaml@main

--- a/everything-presence-lite-ha-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-no-ble-co2.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: DEBUG
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-co2-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble-co2.yaml@main

--- a/everything-presence-lite-ha-no-ble.yaml
+++ b/everything-presence-lite-ha-no-ble.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: DEBUG
+  update_checks: true
 
 
   device_config:
@@ -21,6 +22,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-no-ble-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-no-ble.yaml@main

--- a/everything-presence-lite-ha-sen0395-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble-co2.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -25,6 +26,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-co2-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-co2.yaml@main

--- a/everything-presence-lite-ha-sen0395-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0395-no-ble.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -25,6 +26,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0395-no-ble.yaml@main

--- a/everything-presence-lite-ha-sen0609-no-ble-co2.yaml
+++ b/everything-presence-lite-ha-sen0609-no-ble-co2.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -25,6 +26,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-co2-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-co2.yaml@main

--- a/everything-presence-lite-ha-sen0609-no-ble.yaml
+++ b/everything-presence-lite-ha-sen0609-no-ble.yaml
@@ -4,6 +4,7 @@ substitutions:
   illuminance_update_interval: "2s"
   hidden_ssid: "false"
   log_level: ERROR
+  update_checks: true
 
 
   device_config:
@@ -25,6 +26,7 @@ update:
     name: Everything Presence Lite Firmware
     source: https://everythingsmarthome.github.io/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble-manifest.json
     disabled_by_default: true
+    update_interval: ${"6h" if (update_checks | lower) == "true" else "never"}
 
 dashboard_import:
   package_import_url: github://everythingsmarthome/everything-presence-lite/everything-presence-lite-ha-sen0609-no-ble.yaml@main


### PR DESCRIPTION
## Summary

Add an `update_checks` substitution that allows users to disable automatic firmware manifest checks while preserving the existing default behaviour.

When set to `false`:

- BLE-enabled firmware skips the update check after WiFi connects.
- BLE-enabled firmware skips the six-hour update-check interval.
- BLE scanning is still re-enabled and restarted after WiFi connects.
- No-BLE firmware sets the HTTP update component interval to `never`.
- Manual firmware update actions remain available.

The default is `update_checks: true` and existing behaviour is unchanged unless `update_checks: false` as configured.

## Motivation

Some devices use custom configurations and are isolated on an IoT VLAN where the firmware manifest cannot be reached. For those devices, repeatedly attempting update checks provides no benefit since the update checks fail.

The BLE firmware update path also temporarily stops BLE scanning and disables the radio while checking the manifest. If recovery fails, advertisements stop arriving, which can disrupt established BLE connections through the proxy.

This option allows users to avoid both behaviours without having to override both the entire `interval:` configuration and the Wi-Fi `on_connect:` event handler.

For consistency, "No-BLE" variants (which do not include `common/bluetooth-base.yaml`) also support this new setting with a custom `update_interval` expression to optionally disable the default six-hour polling default via the same `update_checks` substitution.

## Testing

- ESPHome configuration validation passed with `update_checks: false` for representative BLE and no-BLE configurations.
- Existing default behaviour remains enabled with `update_checks: true`.
- An overnight device test confirmed that advertisements continue arriving and a BLE connection successfully reconnects when lost instead of remaining disconnected due to loss of BLE advertisements.